### PR TITLE
Make rspec and rdf load runtime dependencies

### DIFF
--- a/rdf-spec.gemspec
+++ b/rdf-spec.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version      = '>= 1.9.2'
   gem.requirements               = []
-  gem.add_development_dependency 'rdf',       '~> 1.1'
-  gem.add_development_dependency 'rspec',     '~> 3.0'
-  gem.add_development_dependency 'rspec-its', '~> 1.0'
+  gem.add_runtime_dependency     'rdf',       '~> 1.1'
+  gem.add_runtime_dependency     'rspec',     '~> 3.0'
+  gem.add_runtime_dependency     'rspec-its', '~> 1.0'
   gem.add_development_dependency 'yard' ,     '~> 0.8'
   gem.post_install_message       = nil
 end


### PR DESCRIPTION
RSpec, RSpec Its, and RDF.rb are required to run this code. When marked as development dependencies, they are not included in the dependency tree for external projects that use this code.