### PR TITLE
Adjust set arbitrary header test to check for the set value directly

### DIFF
--- a/lib/rdf/spec/http_adapter.rb
+++ b/lib/rdf/spec/http_adapter.rb
@@ -106,7 +106,7 @@ module RDF_HttpAdapter
     it "sets arbitrary header" do
       WebMock.stub_request(:get, uri).to_return(body: "foo", headers: {"Foo" => "Bar"})
       RDF::Util::File.open_file(uri) do |f|
-        expect(f.headers).to include(:foo => %(Bar))
+        expect(f.headers[:foo]).to eq "Bar"
         opened.opened
       end
     end


### PR DESCRIPTION
Hurley wraps its headers in a custom hash-like class that doesn't work well with rspec's `include` matcher. I've tweaked the problematic test to a form that works with the existing HTTP Adapters, as well as Hurley, and hopefully still captures the spirit of the check.