### PR TITLE
Update to use a new shared_example style

### DIFF
--- a/lib/rdf/spec/countable.rb
+++ b/lib/rdf/spec/countable.rb
@@ -45,3 +45,23 @@ RSpec.shared_examples 'an RDF::Countable' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Countable"` instead
+module RDF_Countable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Countable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Countable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Countable' do
+      let(:countable) { @countable }
+
+      before do
+        raise '@countable must be defined' unless defined?(countable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/countable.rb
+++ b/lib/rdf/spec/countable.rb
@@ -1,27 +1,28 @@
 require 'rdf/spec'
 
-module RDF_Countable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Countable' do
   include RDF::Spec::Matchers
 
-  before :each do
-    raise '+@countable+ must be defined in a before(:each) block' unless instance_variable_get('@countable')
+  before do
+    raise 'countable must be set with `let(:countable)' unless
+      defined? countable
 
     @statements = RDF::Spec.quads
 
-    if @countable.empty?
-      if (@countable.writable? rescue false)
-        @countable.insert_statements(@statements)
-      elsif @countable.respond_to?(:<<)
-        @statements.each { |statement| @countable << statement }
+    if countable.empty?
+      if (countable.writable? rescue false)
+        countable.send(:insert_statements, @statements)
+      elsif countable.respond_to?(:<<)
+        @statements.each { |statement| countable << statement }
       else
-        raise "+@countable+ must respond to #<< or be pre-populated with the statements in #{RDF::Spec::TRIPLES_FILE} in a before(:each) block"
+        raise "+countable+ must respond to #<< or be pre-populated with the" \
+              "statements in #{RDF::Spec::TRIPLES_FILE} in a before block"
       end
     end
   end
 
   describe RDF::Countable do
-    subject {@countable}
+    subject {countable}
 
     it {should respond_to(:empty?)}
     it {should_not be_empty}

--- a/lib/rdf/spec/durable.rb
+++ b/lib/rdf/spec/durable.rb
@@ -25,24 +25,40 @@ RSpec.shared_examples 'an RDF::Durable' do
       instance_variable_get('@load_durable')
   end
 
-  describe RDF::Durable do
-    subject {@load_durable.call}
-    it {should respond_to(:durable?)}
-    it "should support #durable?" do
-      expect([true,false]).to be_member(subject.durable?)
-    end
+  subject {@load_durable.call}
 
-    it {should respond_to(:nondurable?)}
-    it "should support #nondurable?" do
-      expect([true,false]).to be_member(@load_durable.call.nondurable?)
-    end
-    its(:nondurable?) {should_not == subject.durable?}
+  it { should respond_to(:durable?) }
 
-    it "should save contents between instantiations" do
-      if subject.durable?
-       subject.load(RDF::Spec::TRIPLES_FILE)
-       expect(subject.count).to eq File.readlines(RDF::Spec::TRIPLES_FILE).size
-      end
+  it "should support #durable?" do
+    expect([true,false]).to be_member(subject.durable?)
+  end
+
+  it {should respond_to(:nondurable?)}
+
+  it "should support #nondurable?" do
+    expect([true,false]).to be_member(@load_durable.call.nondurable?)
+  end
+
+  its(:nondurable?) {should_not == subject.durable?}
+
+  it "should save contents between instantiations" do
+    if subject.durable?
+      subject.load(RDF::Spec::TRIPLES_FILE)
+      expect(subject.count).to eq File.readlines(RDF::Spec::TRIPLES_FILE).size
     end
+  end
+end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Durable"` instead
+module RDF_Durable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Durable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Durable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Durable'
   end
 end

--- a/lib/rdf/spec/durable.rb
+++ b/lib/rdf/spec/durable.rb
@@ -14,15 +14,15 @@ require 'rdf/spec'
 #      File.delete('test.db') if File.exists?('test.db')
 #    end
 #
-#    include RDF_Repository
+#    it_behaves_like 'an RDF::Repository'
 #  end
 #end
-module RDF_Durable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Durable' do
   include RDF::Spec::Matchers
 
   before :each do
-    raise '+@load_durable+ must be defined in a before(:each) block' unless instance_variable_get('@load_durable')
+    raise '+@load_durable+ must be defined in a before(:each) block' unless
+      instance_variable_get('@load_durable')
   end
 
   describe RDF::Durable do

--- a/lib/rdf/spec/enumerable.rb
+++ b/lib/rdf/spec/enumerable.rb
@@ -468,3 +468,23 @@ RSpec.shared_examples 'an RDF::Enumerable' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Enumerable"` instead
+module RDF_Enumerable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Enumerable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Enumerable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Enumerable' do
+      let(:enumerable) { @enumerable }
+
+      before do
+        raise '@enumerable must be defined' unless defined?(enumerable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/enumerable.rb
+++ b/lib/rdf/spec/enumerable.rb
@@ -1,472 +1,470 @@
 require 'rdf/spec'
 
-module RDF_Enumerable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Enumerable' do
   include RDF::Spec::Matchers
 
-  before :each do
-    raise '+@enumerable+ must be defined in a before(:each) block' unless instance_variable_get('@enumerable')
+  before do
+    raise 'enumerable must be set with `let(:enumerable)' unless
+      defined? enumerable
 
     @statements ||= RDF::Spec.quads
 
-    if @enumerable.empty?
-      if (@enumerable.writable? rescue false)
-        @enumerable.insert(*@statements)
-      elsif @enumerable.respond_to?(:<<)
-        @statements.each { |statement| @enumerable << statement }
+    if enumerable.empty?
+      if (enumerable.writable? rescue false)
+        enumerable.insert(*@statements)
+      elsif enumerable.respond_to?(:<<)
+        @statements.each { |statement| enumerable << statement }
       else
         raise "@enumerable must respond to #<< or be pre-populated with the statements in #{RDF::Spec::TRIPLES_FILE} in a before(:each) block"
       end
     end
 
-    @supports_context = @enumerable.supports?(:context) rescue true
+    @supports_context = enumerable.supports?(:context) rescue true
   end
 
-  describe RDF::Enumerable do
-    let(:subject_count) {@statements.map(&:subject).uniq.length}
-    let(:bnode_subject_count) {@statements.map(&:subject).uniq.select(&:node?).length}
-    let(:non_bnode_statements) {@statements.reject {|s| s.subject.node? || s.object.node?}}
+  let(:subject_count) {@statements.map(&:subject).uniq.length}
+  let(:bnode_subject_count) {@statements.map(&:subject).uniq.select(&:node?).length}
+  let(:non_bnode_statements) {@statements.reject {|s| s.subject.node? || s.object.node?}}
 
-    subject {@enumerable}
-    it {should respond_to(:supports?)}
+  subject { enumerable }
+  it {should respond_to(:supports?)}
 
-    describe "valid?" do
-      it "reports validity" do
+  describe "valid?" do
+    it "reports validity" do
+      if subject.supports?(:validity)
+        should be_valid
+      else
+        expect {subject.valid?}.to raise_error(NotImplementedError)
+      end
+    end
+
+    it "returns false if any statement is invalid" do
+      if subject.respond_to?(:<<) && (subject.writable? rescue true)
+        s = RDF::Statement.from([nil, nil, nil])
         if subject.supports?(:validity)
-          should be_valid
+          expect(s).not_to  be_valid
+          subject << s
+          expect(subject).not_to  be_valid
         else
           expect {subject.valid?}.to raise_error(NotImplementedError)
         end
+      else
+        skip("can't add statement to immutable enumerable")
       end
-      
-      it "returns false if any statement is invalid" do
-        if subject.respond_to?(:<<) && (subject.writable? rescue true)
-          s = RDF::Statement.from([nil, nil, nil])
-          if subject.supports?(:validity)
-            expect(s).not_to  be_valid
-            subject << s
-            expect(subject).not_to  be_valid
-          else
-            expect {subject.valid?}.to raise_error(NotImplementedError)
-          end
-        else
-          skip("can't add statement to immutable enumerable")
+    end
+  end
+
+  context "when counting statements" do
+    it {should respond_to(:empty?)}
+    it {should_not be_empty}
+    it {should respond_to(:count)}
+    its(:count) {should == @statements.size}
+    it {should respond_to(:size)}
+    its(:size) {should == @statements.size}
+
+    context "and empty" do
+      subject {[].extend(RDF::Enumerable)}
+      it {should be_empty}
+      its(:count) {should == 0}
+      its(:size) {should == 0}
+    end
+  end
+
+  context "when enumerating statements" do
+    it {should respond_to(:statements)}
+    its(:statements) {should be_an_enumerator}
+
+    context "#statements" do
+      specify {expect(subject.statements.to_a.size).to eq @statements.size}
+      specify {subject.statements.each { |statement| expect(statement).to be_a_statement }}
+    end
+
+    it {should respond_to(:has_statement?)}
+    context "#has_statement?" do
+      let(:unknown_statement) {RDF::Statement.new(RDF::Node.new, RDF::URI.new("http://example.org/unknown"), RDF::Node.new)}
+      it "should have all statements" do
+        # Don't check for BNodes, as equivalence depends on their being exactly the same, not just the same identifier. If subject is loaded separately, these won't match.
+        non_bnode_statements.each do |statement|
+          expect(subject).to have_statement(statement)
         end
       end
-    end
 
-    context "when counting statements" do
-      it {should respond_to(:empty?)}
-      it {should_not be_empty}
-      it {should respond_to(:count)}
-      its(:count) {should == @statements.size}
-      it {should respond_to(:size)}
-      its(:size) {should == @statements.size}
-
-      context "and empty" do
-        subject {[].extend(RDF::Enumerable)}
-        it {should be_empty}
-        its(:count) {should == 0}
-        its(:size) {should == 0}
-      end
-    end
-
-    context "when enumerating statements" do
-      it {should respond_to(:statements)}
-      its(:statements) {should be_an_enumerator}
-
-      context "#statements" do
-        specify {expect(subject.statements.to_a.size).to eq @statements.size}
-        specify {subject.statements.each { |statement| expect(statement).to be_a_statement }}
-      end
-
-      it {should respond_to(:has_statement?)}
-      context "#has_statement?" do
-        let(:unknown_statement) {RDF::Statement.new(RDF::Node.new, RDF::URI.new("http://example.org/unknown"), RDF::Node.new)}
-        it "should have all statements" do
-          # Don't check for BNodes, as equivalence depends on their being exactly the same, not just the same identifier. If subject is loaded separately, these won't match.
+      it "does not have statement in different context" do
+        if @supports_context
+          context = RDF::URI.new("urn:context:1")
           non_bnode_statements.each do |statement|
-            expect(subject).to have_statement(statement)
+            s = statement.dup
+            s.context = context
+            expect(subject).not_to have_statement(s)
           end
-        end
-
-        it "does not have statement in different context" do
-          if @supports_context
-            context = RDF::URI.new("urn:context:1")
-            non_bnode_statements.each do |statement|
-              s = statement.dup
-              s.context = context
-              expect(subject).not_to have_statement(s)
-            end
-          end
-        end
-
-        it "does not have an unknown statement" do
-          expect(subject).not_to have_statement(unknown_statement)
         end
       end
 
-      it {should respond_to(:each_statement)}
-      its(:each_statement) {should be_an_enumerator}
-      it "should implement #each_statement" do
-        subject.each_statement { |statement| expect(statement).to be_a_statement }
+      it "does not have an unknown statement" do
+        expect(subject).not_to have_statement(unknown_statement)
       end
+    end
 
-      it {should respond_to(:enum_statement)}
-      its(:enum_statement) {should be_an_enumerator}
-      its(:enum_statement) {should be_countable}
-      its(:enum_statement) {should be_enumerable}
-      its(:enum_statement) {should be_queryable}
-      context "#enum_statement" do
-        it "should enumerate all statements" do
-          expect(subject.enum_statement.count).to eq @enumerable.each_statement.count
-          subject.enum_statement.each do |s|
-            expect(s).to be_a_statement
-            expect(@enumerable.each_statement.to_a).to include(s) unless s.has_blank_nodes?
-          end
+    it {should respond_to(:each_statement)}
+    its(:each_statement) {should be_an_enumerator}
+    it "should implement #each_statement" do
+      subject.each_statement { |statement| expect(statement).to be_a_statement }
+    end
+
+    it {should respond_to(:enum_statement)}
+    its(:enum_statement) {should be_an_enumerator}
+    its(:enum_statement) {should be_countable}
+    its(:enum_statement) {should be_enumerable}
+    its(:enum_statement) {should be_queryable}
+    context "#enum_statement" do
+      it "should enumerate all statements" do
+        expect(subject.enum_statement.count).to eq enumerable.each_statement.count
+        subject.enum_statement.each do |s|
+          expect(s).to be_a_statement
+          expect(enumerable.each_statement.to_a).to include(s) unless s.has_blank_nodes?
+        end
+      end
+    end
+  end
+
+  context "when enumerating triples" do
+    it {should respond_to(:triples)}
+    it {should respond_to(:has_triple?)}
+    it {should respond_to(:each_triple)}
+    it {should respond_to(:enum_triple)}
+
+    its(:triples) {should be_an_enumerator}
+    context "#triples" do
+      specify {expect(subject.triples.to_a.size).to eq @statements.size}
+      specify {subject.triples.each { |triple| expect(triple).to be_a_triple }}
+    end
+
+    context "#has_triple?" do
+      specify do
+        non_bnode_statements.each do |statement|
+          expect(subject).to have_triple(statement.to_triple)
         end
       end
     end
 
-    context "when enumerating triples" do
-      it {should respond_to(:triples)}
-      it {should respond_to(:has_triple?)}
-      it {should respond_to(:each_triple)}
-      it {should respond_to(:enum_triple)}
-
-      its(:triples) {should be_an_enumerator}
-      context "#triples" do
-        specify {expect(subject.triples.to_a.size).to eq @statements.size}
-        specify {subject.triples.each { |triple| expect(triple).to be_a_triple }}
+    its(:each_triple) {should be_an_enumerator}
+    context "#each_triple" do
+      specify {subject.each_triple { |*triple| expect(triple).to be_a_triple }}
+      it "should iterate over all triples" do
+        subject.each_triple do |*triple|
+          triple.each {|r| expect(r).to be_a_term}
+          expect(enumerable).to have_triple(triple) unless triple.any?(&:node?)
+        end
       end
+    end
 
-      context "#has_triple?" do
-        specify do
+    its(:enum_triple) {should be_an_enumerator}
+    its(:enum_triple) {should be_countable}
+    context "#enum_triple" do
+      it "should enumerate all triples" do
+        expect(subject.enum_triple.count).to eq enumerable.each_triple.count
+        subject.enum_triple.each do |s, p, o|
+          [s, p, o].each {|r| expect(r).to be_a_term}
+          expect(enumerable).to have_triple([s, p, o]) unless [s, p, o].any?(&:node?)
+        end
+      end
+    end
+  end
+
+  context "when enumerating quads" do
+    it {should respond_to(:quads)}
+    it {should respond_to(:has_quad?)}
+    it {should respond_to(:each_quad)}
+    it {should respond_to(:enum_quad)}
+
+    its(:quads) {should be_an_enumerator}
+    context "#quads" do
+      specify {expect(subject.quads.to_a.size).to eq @statements.size}
+      specify {subject.quads.each { |quad| expect(quad).to be_a_quad }}
+    end
+
+    context "#has_quad?" do
+      specify do
+        if @supports_context
           non_bnode_statements.each do |statement|
-            expect(subject).to have_triple(statement.to_triple)
-          end
-        end
-      end
-
-      its(:each_triple) {should be_an_enumerator}
-      context "#each_triple" do
-        specify {subject.each_triple { |*triple| expect(triple).to be_a_triple }}
-        it "should iterate over all triples" do
-          subject.each_triple do |*triple|
-            triple.each {|r| expect(r).to be_a_term}
-            expect(@enumerable).to have_triple(triple) unless triple.any?(&:node?)
-          end
-        end
-      end
-
-      its(:enum_triple) {should be_an_enumerator}
-      its(:enum_triple) {should be_countable}
-      context "#enum_triple" do
-        it "should enumerate all triples" do
-          expect(subject.enum_triple.count).to eq @enumerable.each_triple.count
-          subject.enum_triple.each do |s, p, o|
-            [s, p, o].each {|r| expect(r).to be_a_term}
-            expect(@enumerable).to have_triple([s, p, o]) unless [s, p, o].any?(&:node?)
+            expect(subject).to have_quad(statement.to_quad)
           end
         end
       end
     end
 
-    context "when enumerating quads" do
-      it {should respond_to(:quads)}
-      it {should respond_to(:has_quad?)}
-      it {should respond_to(:each_quad)}
-      it {should respond_to(:enum_quad)}
-
-      its(:quads) {should be_an_enumerator}
-      context "#quads" do
-        specify {expect(subject.quads.to_a.size).to eq @statements.size}
-        specify {subject.quads.each { |quad| expect(quad).to be_a_quad }}
-      end
-
-      context "#has_quad?" do
-        specify do
-          if @supports_context
-            non_bnode_statements.each do |statement|
-              expect(subject).to have_quad(statement.to_quad)
-            end
-          end
-        end
-      end
-
-      its(:each_quad) {should be_an_enumerator}
-      context "#each_quad" do
-        specify {subject.each_quad {|*quad| expect(quad).to be_a_quad }}
-        it "should iterate over all quads" do
-          subject.each_quad do |*quad|
-            quad.compact.each {|r| expect(r).to be_a_term}
-            expect(@enumerable).to have_quad(quad) unless quad.compact.any?(&:node?)
-          end
-        end
-      end
-
-      its(:enum_quad) {should be_an_enumerator}
-      its(:enum_quad) {should be_countable}
-      context "#enum_quad" do
-        it "should enumerate all quads" do
-          expect(subject.enum_quad.count).to eq @enumerable.each_quad.count
-          subject.enum_quad.each do |s, p, o, c|
-            [s, p, o, c].compact.each {|r| expect(r).to be_a_term}
-            expect(@enumerable).to have_quad([s, p, o, c]) unless [s, p, o].any?(&:node?)
-          end
+    its(:each_quad) {should be_an_enumerator}
+    context "#each_quad" do
+      specify {subject.each_quad {|*quad| expect(quad).to be_a_quad }}
+      it "should iterate over all quads" do
+        subject.each_quad do |*quad|
+          quad.compact.each {|r| expect(r).to be_a_term}
+          expect(enumerable).to have_quad(quad) unless quad.compact.any?(&:node?)
         end
       end
     end
 
-    context "when enumerating subjects" do
-      let(:subjects) {subject.map { |s| s.subject }.reject(&:node?).uniq}
-      it {should respond_to(:subjects)}
-      it {should respond_to(:has_subject?)}
-      it {should respond_to(:each_subject)}
-      it {should respond_to(:enum_subject)}
+    its(:enum_quad) {should be_an_enumerator}
+    its(:enum_quad) {should be_countable}
+    context "#enum_quad" do
+      it "should enumerate all quads" do
+        expect(subject.enum_quad.count).to eq enumerable.each_quad.count
+        subject.enum_quad.each do |s, p, o, c|
+          [s, p, o, c].compact.each {|r| expect(r).to be_a_term}
+          expect(enumerable).to have_quad([s, p, o, c]) unless [s, p, o].any?(&:node?)
+        end
+      end
+    end
+  end
 
-      its(:subjects) {should be_an_enumerator}
-      context "#subjects" do
-        subject {@enumerable.subjects}
+  context "when enumerating subjects" do
+    let(:subjects) {subject.map { |s| s.subject }.reject(&:node?).uniq}
+    it {should respond_to(:subjects)}
+    it {should respond_to(:has_subject?)}
+    it {should respond_to(:each_subject)}
+    it {should respond_to(:enum_subject)}
+
+    its(:subjects) {should be_an_enumerator}
+    context "#subjects" do
+      subject { enumerable.subjects }
+      specify {expect(subject).to be_an_enumerator}
+      specify {subject.each { |value| expect(value).to be_a_resource }}
+      context ":unique => false" do
+        subject { enumerable.subjects(:unique => false) }
         specify {expect(subject).to be_an_enumerator}
         specify {subject.each { |value| expect(value).to be_a_resource }}
-        context ":unique => false" do
-          subject {@enumerable.subjects(:unique => false)}
-          specify {expect(subject).to be_an_enumerator}
-          specify {subject.each { |value| expect(value).to be_a_resource }}
-        end
-      end
-
-      context "#has_subject?" do
-        specify do
-          checked = []
-          non_bnode_statements.each do |statement|
-            expect(@enumerable).to have_subject(statement.subject) unless checked.include?(statement.subject)
-            checked << statement.subject
-          end
-          uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
-          expect(@enumerable).not_to have_subject(uri)
-        end
-      end
-
-      its(:each_subject) {should be_an_enumerator}
-      context "#each_subject" do
-        specify {expect(subject.each_subject.reject(&:node?).size).to eq subjects.reject(&:node?).size}
-        specify {subject.each_subject {|value| expect(value).to be_a_resource}}
-        specify {subject.each_subject {|value| expect(subjects).to include(value) unless value.node?}}
-      end
-
-      its(:enum_subject) {should be_an_enumerator}
-      its(:enum_subject) {should be_countable}
-      context "#enum_subject" do
-        specify {expect(subject.enum_subject.to_a.reject(&:node?).size).to eq subjects.reject(&:node?).size}
-        it "should enumerate all subjects" do
-          subject.enum_subject.each do |s|
-            expect(s).to be_a_resource
-            expect(subjects.to_a).to include(s) unless s.node?
-          end
-        end
       end
     end
 
-    context "when enumerating predicates" do
-      let(:predicates) {@statements.map { |s| s.predicate }.uniq}
-      it {should respond_to(:predicates)}
-      it {should respond_to(:has_predicate?)}
-      it {should respond_to(:each_predicate)}
-      it {should respond_to(:enum_predicate)}
+    context "#has_subject?" do
+      specify do
+        checked = []
+        non_bnode_statements.each do |statement|
+          expect(enumerable).to have_subject(statement.subject) unless checked.include?(statement.subject)
+          checked << statement.subject
+        end
+        uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
+        expect(enumerable).not_to have_subject(uri)
+      end
+    end
 
-      its(:predicates) {should be_an_enumerator}
-      context "#predicates" do
-        subject {@enumerable.predicates}
+    its(:each_subject) {should be_an_enumerator}
+    context "#each_subject" do
+      specify {expect(subject.each_subject.reject(&:node?).size).to eq subjects.reject(&:node?).size}
+      specify {subject.each_subject {|value| expect(value).to be_a_resource}}
+      specify {subject.each_subject {|value| expect(subjects).to include(value) unless value.node?}}
+    end
+
+    its(:enum_subject) {should be_an_enumerator}
+    its(:enum_subject) {should be_countable}
+    context "#enum_subject" do
+      specify {expect(subject.enum_subject.to_a.reject(&:node?).size).to eq subjects.reject(&:node?).size}
+      it "should enumerate all subjects" do
+        subject.enum_subject.each do |s|
+          expect(s).to be_a_resource
+          expect(subjects.to_a).to include(s) unless s.node?
+        end
+      end
+    end
+  end
+
+  context "when enumerating predicates" do
+    let(:predicates) {@statements.map { |s| s.predicate }.uniq}
+    it {should respond_to(:predicates)}
+    it {should respond_to(:has_predicate?)}
+    it {should respond_to(:each_predicate)}
+    it {should respond_to(:enum_predicate)}
+
+    its(:predicates) {should be_an_enumerator}
+    context "#predicates" do
+      subject { enumerable.predicates }
+      specify {expect(subject).to be_an_enumerator}
+      specify {subject.each { |value| expect(value).to be_a_uri }}
+      context ":unique => false" do
+        subject { enumerable.predicates(:unique => false) }
         specify {expect(subject).to be_an_enumerator}
         specify {subject.each { |value| expect(value).to be_a_uri }}
-        context ":unique => false" do
-          subject {@enumerable.predicates(:unique => false)}
-          specify {expect(subject).to be_an_enumerator}
-          specify {subject.each { |value| expect(value).to be_a_uri }}
-        end
-      end
-
-      context "#has_predicate?" do
-        specify do
-          checked = []
-          @statements.each do |statement|
-            expect(@enumerable).to have_predicate(statement.predicate) unless checked.include?(statement.predicate)
-            checked << statement.predicate
-          end
-          uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
-          expect(@enumerable).not_to have_predicate(uri)
-        end
-      end
-
-      its(:each_predicate) {should be_an_enumerator}
-      context "#each_predicate" do
-        specify {expect(subject.each_predicate.to_a.size).to eq predicates.size}
-        specify {subject.each_predicate {|value| expect(value).to be_a_uri}}
-        specify {subject.each_predicate {|value| expect(predicates).to include(value)}}
-      end
-
-      its(:enum_predicate) {should be_an_enumerator}
-      its(:enum_predicate) {should be_countable}
-      context "#enum_predicate" do
-        it "should enumerate all predicates" do
-          expect(subject.enum_predicate.to_a).to include(*predicates)
-        end
       end
     end
 
-    context "when enumerating objects" do
-      let(:objects) {subject.map(&:object).reject(&:node?).uniq}
-      it {should respond_to(:objects)}
-      it {should respond_to(:has_object?)}
-      it {should respond_to(:each_object)}
-      it {should respond_to(:enum_object)}
+    context "#has_predicate?" do
+      specify do
+        checked = []
+        @statements.each do |statement|
+          expect(enumerable).to have_predicate(statement.predicate) unless checked.include?(statement.predicate)
+          checked << statement.predicate
+        end
+        uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
+        expect(enumerable).not_to have_predicate(uri)
+      end
+    end
 
-      its(:objects) {should be_an_enumerator}
-      context "#objects" do
-        subject {@enumerable.objects}
+    its(:each_predicate) {should be_an_enumerator}
+    context "#each_predicate" do
+      specify {expect(subject.each_predicate.to_a.size).to eq predicates.size}
+      specify {subject.each_predicate {|value| expect(value).to be_a_uri}}
+      specify {subject.each_predicate {|value| expect(predicates).to include(value)}}
+    end
+
+    its(:enum_predicate) {should be_an_enumerator}
+    its(:enum_predicate) {should be_countable}
+    context "#enum_predicate" do
+      it "should enumerate all predicates" do
+        expect(subject.enum_predicate.to_a).to include(*predicates)
+      end
+    end
+  end
+
+  context "when enumerating objects" do
+    let(:objects) {subject.map(&:object).reject(&:node?).uniq}
+    it {should respond_to(:objects)}
+    it {should respond_to(:has_object?)}
+    it {should respond_to(:each_object)}
+    it {should respond_to(:enum_object)}
+
+    its(:objects) {should be_an_enumerator}
+    context "#objects" do
+      subject { enumerable.objects }
+      specify {expect(subject).to be_an_enumerator}
+      specify {subject.each { |value| expect(value).to be_a_term }}
+      context ":unique => false" do
+        subject { enumerable.objects(:unique => false) }
         specify {expect(subject).to be_an_enumerator}
         specify {subject.each { |value| expect(value).to be_a_term }}
-        context ":unique => false" do
-          subject {@enumerable.objects(:unique => false)}
-          specify {expect(subject).to be_an_enumerator}
-          specify {subject.each { |value| expect(value).to be_a_term }}
-        end
-      end
-
-      context "#has_object?" do
-        specify do
-          checked = []
-          non_bnode_statements.each do |statement|
-            expect(@enumerable).to have_object(statement.object) unless checked.include?(statement.object)
-            checked << statement.object
-          end
-          uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
-          expect(@enumerable).not_to have_object(uri)
-        end
-      end
-
-      its(:each_object) {should be_an_enumerator}
-      context "#each_object" do
-        specify {expect(subject.each_object.reject(&:node?).size).to eq objects.size}
-        specify {subject.each_object {|value| expect(value).to be_a_term}}
-        specify {subject.each_object {|value| expect(objects).to include(value) unless value.node?}}
-      end
-
-      its(:enum_object) {should be_an_enumerator}
-      its(:enum_object) {should be_countable}
-      context "#enum_object" do
-        it "should enumerate all objects" do
-          subject.enum_object.each do |o|
-            expect(o).to be_a_term
-            expect(objects.to_a).to include(o) unless o.node?
-          end
-        end
       end
     end
 
-    context "when enumerating contexts" do
-      it {should respond_to(:contexts)}
-      it {should respond_to(:has_context?)}
-      it {should respond_to(:each_context)}
-      it {should respond_to(:enum_context)}
+    context "#has_object?" do
+      specify do
+        checked = []
+        non_bnode_statements.each do |statement|
+          expect(enumerable).to have_object(statement.object) unless checked.include?(statement.object)
+          checked << statement.object
+        end
+        uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
+        expect(enumerable).not_to have_object(uri)
+      end
+    end
 
-      its(:contexts) {should be_an_enumerator}
-      describe "#contexts" do
-        subject {@enumerable.contexts}
+    its(:each_object) {should be_an_enumerator}
+    context "#each_object" do
+      specify {expect(subject.each_object.reject(&:node?).size).to eq objects.size}
+      specify {subject.each_object {|value| expect(value).to be_a_term}}
+      specify {subject.each_object {|value| expect(objects).to include(value) unless value.node?}}
+    end
+
+    its(:enum_object) {should be_an_enumerator}
+    its(:enum_object) {should be_countable}
+    context "#enum_object" do
+      it "should enumerate all objects" do
+        subject.enum_object.each do |o|
+          expect(o).to be_a_term
+          expect(objects.to_a).to include(o) unless o.node?
+        end
+      end
+    end
+  end
+
+  context "when enumerating contexts" do
+    it {should respond_to(:contexts)}
+    it {should respond_to(:has_context?)}
+    it {should respond_to(:each_context)}
+    it {should respond_to(:enum_context)}
+
+    its(:contexts) {should be_an_enumerator}
+    describe "#contexts" do
+      subject { enumerable.contexts }
+      specify {expect(subject).to be_an_enumerator}
+      it "values should be resources" do
+        subject.each { |value| expect(value).to be_a_resource }
+      end
+      context ":unique => false" do
+        subject { enumerable.contexts(:unique => false) }
         specify {expect(subject).to be_an_enumerator}
         it "values should be resources" do
           subject.each { |value| expect(value).to be_a_resource }
         end
-        context ":unique => false" do
-          subject {@enumerable.contexts(:unique => false)}
-          specify {expect(subject).to be_an_enumerator}
-          it "values should be resources" do
-            subject.each { |value| expect(value).to be_a_resource }
+      end
+    end
+
+    it "should implement #has_context?" do
+      if @supports_context
+        @statements.each do |statement|
+          if statement.has_context?
+            expect(enumerable).to have_context(statement.context)
           end
         end
+        uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
+        expect(enumerable).not_to have_context(uri)
       end
+    end
 
-      it "should implement #has_context?" do
+    its(:each_context) {should be_an_enumerator}
+    context "#each_context" do
+      let(:contexts) {@statements.map { |s| s.context }.uniq.compact}
+      it "has appropriate number of contexts" do
         if @supports_context
-          @statements.each do |statement|
-            if statement.has_context?
-              expect(@enumerable).to have_context(statement.context)
-            end
-          end
-          uri = RDF::URI.new('http://example.org/does/not/have/this/uri')
-          expect(@enumerable).not_to have_context(uri)
+          expect(subject.each_context.to_a.size).to eq contexts.size
         end
       end
-
-      its(:each_context) {should be_an_enumerator}
-      context "#each_context" do
-        let(:contexts) {@statements.map { |s| s.context }.uniq.compact}
-        it "has appropriate number of contexts" do
-          if @supports_context
-            expect(subject.each_context.to_a.size).to eq contexts.size
-          end
-        end
-        it "values should be resources" do
-          subject.each_context {|value| expect(value).to be_a_resource}
-        end
-        it "should have all contexts" do
-          subject.each_context {|value| expect(contexts).to include(value)}
-        end
+      it "values should be resources" do
+        subject.each_context {|value| expect(value).to be_a_resource}
       end
-
-      its(:enum_context) {should be_an_enumerator}
-      its(:enum_context) {should be_countable}
-      context "#enum_context" do
-        it "should enumerate all contexts" do
-          expect(subject.enum_context.to_a).to include(*@enumerable.each_context.to_a)
-        end
+      it "should have all contexts" do
+        subject.each_context {|value| expect(contexts).to include(value)}
       end
     end
 
-    context "when enumerating graphs" do
-      it {should respond_to(:each_graph)}
-      it {should respond_to(:enum_graph)}
-
-      describe "#each_graph" do
-        subject {@enumerable.each_graph}
-        it {should be_an_enumerator}
-        it "are all graphs" do
-          subject.each { |value| expect(value).to be_a_graph } if @supports_context
-        end
+    its(:enum_context) {should be_an_enumerator}
+    its(:enum_context) {should be_countable}
+    context "#enum_context" do
+      it "should enumerate all contexts" do
+        expect(subject.enum_context.to_a).to include(*enumerable.each_context.to_a)
       end
+    end
+  end
 
-      describe "#enum_graph" do
-        subject {@enumerable.enum_graph}
-        it {should be_an_enumerator}
-        it {should be_countable}
-        it "enumerates the same as #each_graph" do
-          expect(subject.to_a).to include(*@enumerable.each_graph.to_a) if @supports_context # expect with match problematic
-        end
+  context "when enumerating graphs" do
+    it {should respond_to(:each_graph)}
+    it {should respond_to(:enum_graph)}
+
+    describe "#each_graph" do
+      subject { enumerable.each_graph }
+      it {should be_an_enumerator}
+      it "are all graphs" do
+        subject.each { |value| expect(value).to be_a_graph } if @supports_context
       end
     end
 
-    context "when converting" do
-      it {should respond_to(:to_hash)}
-      its(:to_hash) {should be_instance_of(Hash)}
-      context "#to_hash" do
-        it "should have as many keys as subjects" do
-          expect(subject.to_hash.keys.size).to eq @enumerable.subjects.to_a.size
-        end
+    describe "#enum_graph" do
+      subject { enumerable.enum_graph }
+      it {should be_an_enumerator}
+      it {should be_countable}
+      it "enumerates the same as #each_graph" do
+        expect(subject.to_a).to include(*enumerable.each_graph.to_a) if @supports_context # expect with match problematic
       end
     end
-  
-    context "when dumping" do
-      it {should respond_to(:dump)}
-    
-      it "should implement #dump" do
-        expect(subject.dump(:ntriples)).to eq RDF::NTriples::Writer.buffer() {|w| w << @enumerable}
+  end
+
+  context "when converting" do
+    it {should respond_to(:to_hash)}
+    its(:to_hash) {should be_instance_of(Hash)}
+    context "#to_hash" do
+      it "should have as many keys as subjects" do
+        expect(subject.to_hash.keys.size).to eq enumerable.subjects.to_a.size
       end
-    
-      it "raises error on unknown format" do
-        expect {subject.dump(:foobar)}.to raise_error(RDF::WriterError, /No writer found/)
-      end
+    end
+  end
+
+  context "when dumping" do
+    it {should respond_to(:dump)}
+
+    it "should implement #dump" do
+      expect(subject.dump(:ntriples)).to eq RDF::NTriples::Writer.buffer() {|w| w << enumerable}
+    end
+
+    it "raises error on unknown format" do
+      expect {subject.dump(:foobar)}.to raise_error(RDF::WriterError, /No writer found/)
     end
   end
 end

--- a/lib/rdf/spec/format.rb
+++ b/lib/rdf/spec/format.rb
@@ -1,53 +1,52 @@
 require 'rdf/spec'
 
-module RDF_Format
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Format' do
   include RDF::Spec::Matchers
 
   before(:each) do
-    raise raise '+@format_class+ must be defined in a before(:each) block' unless instance_variable_get('@format_class')
+    raise 'format_class must be defined with let(:format_class)' unless
+      defined? format_class
   end
 
-  describe RDF::Format do
-    subject {@format_class}
-    describe ".for" do
-      RDF::Format.file_extensions.each do |ext, formats|
-        it "detects #{formats.first} using file path foo.#{ext}" do
-          expect(RDF::Format.for("foo.#{ext}")).to eq formats.first
-        end
+  subject { format_class }
 
-        it "detects #{formats.first} using file_name foo.#{ext}" do
-          expect(RDF::Format.for(:file_name => "foo.#{ext}")).to eq formats.first
-        end
-
-        it "detects #{formats.first} using file_extension #{ext}" do
-          expect(RDF::Format.for(:file_extension => ext)).to eq formats.first
-        end
+  describe ".for" do
+    RDF::Format.file_extensions.each do |ext, formats|
+      it "detects #{formats.first} using file path foo.#{ext}" do
+        expect(RDF::Format.for("foo.#{ext}")).to eq formats.first
       end
 
-      RDF::Format.content_types.each do |content_type, formats|
-        it "detects #{formats.first} using content_type #{content_type}" do
-          expect(RDF::Format.for(:content_type => content_type)).to eq formats.first
-        end
+      it "detects #{formats.first} using file_name foo.#{ext}" do
+        expect(RDF::Format.for(:file_name => "foo.#{ext}")).to eq formats.first
+      end
+
+      it "detects #{formats.first} using file_extension #{ext}" do
+        expect(RDF::Format.for(:file_extension => ext)).to eq formats.first
       end
     end
-  
-    describe ".reader" do
-      it "returns a reader" do
-        subject.each do |f|
-          expect(f.reader).not_to  be_nil
-        end
+
+    RDF::Format.content_types.each do |content_type, formats|
+      it "detects #{formats.first} using content_type #{content_type}" do
+        expect(RDF::Format.for(:content_type => content_type)).to eq formats.first
       end
     end
-  
-    describe ".writer" do
-      ##
-      # May not return a writer, only does if one is defined by the format
-      it "returns a writer" do
-        subject.each do |f|
-          format_namespace = f.name.split('::')[0..-2].inject(Kernel) {|base, const| base.const_get(const)}
-          expect(f.writer).not_to  be_nil if format_namespace.const_defined?(:Writer)
-        end
+  end
+
+  describe ".reader" do
+    it "returns a reader" do
+      subject.each do |f|
+        expect(f.reader).not_to  be_nil
+      end
+    end
+  end
+
+  describe ".writer" do
+    ##
+    # May not return a writer, only does if one is defined by the format
+    it "returns a writer" do
+      subject.each do |f|
+        format_namespace = f.name.split('::')[0..-2].inject(Kernel) {|base, const| base.const_get(const)}
+        expect(f.writer).not_to  be_nil if format_namespace.const_defined?(:Writer)
       end
     end
   end

--- a/lib/rdf/spec/format.rb
+++ b/lib/rdf/spec/format.rb
@@ -51,3 +51,23 @@ RSpec.shared_examples 'an RDF::Format' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Format"` instead
+module RDF_Format
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Format` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Format'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Format' do
+      let(:format_class) { @format_class }
+
+      before do
+        raise '@format_class must be defined' unless defined?(format_class)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/http_adapter.rb
+++ b/lib/rdf/spec/http_adapter.rb
@@ -269,3 +269,23 @@ RSpec.shared_examples 'an RDF::HttpAdapter' do
   end
 
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::HttpAdapter"` instead
+module RDF_HttpAdapter
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_HttpAdapter` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::HttpAdapter'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::HttpAdapter' do
+      let(:http_adapter) { @http_adapter }
+
+      before do
+        raise '@http_adapter must be defined' unless defined?(http_adapter)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/http_adapter.rb
+++ b/lib/rdf/spec/http_adapter.rb
@@ -1,30 +1,24 @@
 require 'rdf/spec'
 require 'webmock/rspec'
 
-module RDF_HttpAdapter
-  extend RSpec::SharedContext
-
+RSpec.shared_examples 'an RDF::HttpAdapter' do
   DOAP_FILE = File.expand_path("../../../../etc/doap.nt", __FILE__)
 
   before(:each) do
-    raise '+@http_adapter+ must be defined in a before(:each) block' unless instance_variable_get('@http_adapter')
+    raise '`http_adapter` must be defined with `let(:http_adapter`' unless
+      defined? http_adapter
   end
-  
+
   let(:uri) {"http://ruby-rdf.github.com/rdf/etc/doap.nt"}
-  
+
   let(:opened) {double("opened")}
   before(:each) do
     expect(opened).to receive(:opened)
   end
 
   context "using a HTTP client" do
-    before do
-      RDF::Util::File.http_adapter = @http_adapter
-    end
-
-    after do
-      RDF::Util::File.http_adapter = nil
-    end
+    before { RDF::Util::File.http_adapter = http_adapter }
+    after { RDF::Util::File.http_adapter = nil }
 
     it "returns an http URL" do
       WebMock.stub_request(:get, uri).
@@ -273,5 +267,5 @@ module RDF_HttpAdapter
       end
     end
   end
-  
+
 end

--- a/lib/rdf/spec/indexable.rb
+++ b/lib/rdf/spec/indexable.rb
@@ -23,3 +23,23 @@ RSpec.shared_examples 'an RDF::Indexable' do
   end
 
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Indexable"` instead
+module RDF_Indexable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Indexable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Indexable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Indexable' do
+      let(:indexable) { @indexable }
+
+      before do
+        raise '@indexable must be defined' unless defined?(indexable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/indexable.rb
+++ b/lib/rdf/spec/indexable.rb
@@ -1,25 +1,25 @@
 require 'rdf/spec'
 
-module RDF_Indexable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Indexable' do
   include RDF::Spec::Matchers
 
   before :each do
-    raise '+@indexable+ must be defined in a before(:each) block' unless instance_variable_get('@indexable')
+    raise 'indexable must be defined with let(:indexable)' unless
+      defined? indexable
   end
 
-  describe RDF::Indexable do
-    subject {@indexable}
-    it {should respond_to(:indexed?)}
-    its(:indexed?) {should == subject.indexed?}
-    it {should respond_to(:index!)}
-  
-    it "does not raise error on #index! if #indexed?" do
-      expect {subject.index!}.not_to raise_error if subject.indexed?
-    end
-  
-    it "raises error on #index! if not #indexed?" do
-      expect {subject.index!}.to raise_error unless subject.indexed?
-    end
+  subject { indexable }
+
+  it {should respond_to(:indexed?)}
+  its(:indexed?) {should == subject.indexed?}
+  it {should respond_to(:index!)}
+
+  it "does not raise error on #index! if #indexed?" do
+    expect {subject.index!}.not_to raise_error if subject.indexed?
   end
+
+  it "raises error on #index! if not #indexed?" do
+    expect {subject.index!}.to raise_error unless subject.indexed?
+  end
+
 end

--- a/lib/rdf/spec/inferable.rb
+++ b/lib/rdf/spec/inferable.rb
@@ -5,3 +5,17 @@ RSpec.shared_examples 'an RDF::Inferable' do
 
   it "should implement specs" #TODO
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Inferable"` instead
+module RDF_Inferable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Inferable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Inferable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Inferable'
+  end
+end

--- a/lib/rdf/spec/inferable.rb
+++ b/lib/rdf/spec/inferable.rb
@@ -1,10 +1,7 @@
 require 'rdf/spec'
 
-module RDF_Inferable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Inferable' do
   include RDF::Spec::Matchers
 
-  describe RDF::Inferable do
-    it "should implement specs" #TODO
-  end
+  it "should implement specs" #TODO
 end

--- a/lib/rdf/spec/mutable.rb
+++ b/lib/rdf/spec/mutable.rb
@@ -1,39 +1,34 @@
 require 'rdf/spec'
 require 'rdf/ntriples'
 
-module RDF_Mutable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Mutable' do
   include RDF::Spec::Matchers
 
-  before :each do
-    raise '+@mutable+ must be defined in a before(:each) block' unless instance_variable_get('@mutable')
+  before do
+    raise 'mutable must be defined with let(:mutable)' unless
+      defined? mutable
 
-    @supports_context = @mutable.respond_to?(:supports?) && @mutable.supports?(:context)
+    @supports_context = mutable.respond_to?(:supports?) && mutable.supports?(:context)
   end
-  let(:resource) {RDF::URI('http://rubygems.org/gems/rdf')}
-  let(:context) {RDF::URI('http://example.org/context')}
+
+  let(:resource) { RDF::URI('http://rubygems.org/gems/rdf') }
+  let(:context) { RDF::URI('http://example.org/context') }
 
   describe RDF::Mutable do
-    subject {@mutable}
+    subject { mutable }
 
     context "readability" do
       require 'rdf/spec/readable'
 
-      before :each do
-        @readable = @mutable
-      end
-
-      include RDF_Readable
+      let(:readable) { mutable }
+      it_behaves_like 'an RDF::Readable'
     end
 
     context "writability" do
       require 'rdf/spec/writable'
 
-      before :each do
-        @writable = @mutable
-      end
-
-      include RDF_Writable
+      let(:writable) { mutable }
+      it_behaves_like 'an RDF::Writable'
     end
 
     it {should be_empty}

--- a/lib/rdf/spec/mutable.rb
+++ b/lib/rdf/spec/mutable.rb
@@ -143,3 +143,23 @@ RSpec.shared_examples 'an RDF::Mutable' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Mutable"` instead
+module RDF_Mutable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Mutable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Mutable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Mutable' do
+      let(:mutable) { @mutable }
+
+      before do
+        raise '@mutable must be defined' unless defined?(mutable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/queryable.rb
+++ b/lib/rdf/spec/queryable.rb
@@ -527,3 +527,23 @@ RSpec.shared_examples 'an RDF::Queryable' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Queryable"` instead
+module RDF_Queryable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Queryable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Queryable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Queryable' do
+      let(:queryable) { @queryable }
+
+      before do
+        raise '@queryable must be defined' unless defined?(queryable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/queryable.rb
+++ b/lib/rdf/spec/queryable.rb
@@ -1,28 +1,28 @@
 require 'rdf/spec'
 
-module RDF_Queryable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Queryable' do
   include RDF::Spec::Matchers
 
   before :each do
-    raise '+@queryable+ must be defined in a before(:each) block' unless instance_variable_get('@queryable')
+    raise 'querable must be set with `let(:queryable)' unless
+      defined? queryable
 
     @doap = RDF::Spec::QUADS_FILE
     @statements = RDF::Spec.quads
 
-    if @queryable.empty?
-      if (@queryable.writable? rescue false)
-        @queryable.insert(*@statements)
-      elsif @queryable.respond_to?(:<<)
-        @statements.each { |statement| @queryable << statement }
+    if queryable.empty?
+      if (queryable.writable? rescue false)
+        queryable.insert(*@statements)
+      elsif queryable.respond_to?(:<<)
+        @statements.each { |statement| queryable << statement }
       else
-        raise "@queryable must respond to #<< or be pre-populated with the statements in #{@doap} in a before(:each) block"
+        raise "queryable must respond to #<< or be pre-populated with the statements in #{@doap} in a before(:each) block"
       end
     end
   end
 
   describe RDF::Queryable do
-    subject {@queryable}
+    subject {queryable}
     let(:resource) {RDF::URI('http://rubygems.org/gems/rdf')}
     let(:literal) {RDF::Literal.new('J. Random Hacker')}
     let(:query) {RDF::Query.new {pattern [:s, :p, :o]}}
@@ -186,24 +186,37 @@ module RDF_Queryable
           # From data-r2/expr-equals
           context "data/r2/expr-equals" do
             context "graph-1" do
-              subject {@queryable.query(:predicate => RDF::URI("http://example.org/p"), :object => RDF::Literal::Integer.new(1)).to_a}
-              its(:count) {should == 2}
+              let(:result) do
+                queryable.query(:predicate => RDF::URI("http://example.org/p"),
+                                :object => RDF::Literal::Integer.new(1)).to_a
+              end
 
-              it "has two solutions" do
-                expect(subject.any? {|s| s.subject == RDF::URI("http://example.org/xi1")}).to be_truthy
+              it 'has two solutions' do
+                expect(result.count).to eq 2
+              end
+
+              it "has xi1 as a solution" do
+                expect(result.any? {|s| s.subject == RDF::URI("http://example.org/xi1")}).to be_truthy
               end
 
               it "has xi2 as a solution" do
-                expect(subject.any? {|s| s.subject == RDF::URI("http://example.org/xi2")}).to be_truthy
+                expect(result.any? {|s| s.subject == RDF::URI("http://example.org/xi2")}).to be_truthy
               end
             end
 
             context "graph-2" do
-              subject {@queryable.query(:predicate => RDF::URI("http://example.org/p"), :object => RDF::Literal::Double.new("1.0e0")).to_a}
-              its(:count) {should == 1}
+              let(:result) do
+                queryable.query(:predicate => RDF::URI("http://example.org/p"),
+                                :object => RDF::Literal::Double.new("1.0e0"))
+                  .to_a
+              end
+
+              it 'has one solution' do
+                expect(result.count).to eq 1
+              end
 
               it "has xd1 as a solution" do
-                expect(subject.any? {|s| s.subject == RDF::URI("http://example.org/xd1")}).to be_truthy
+                expect(result.any? {|s| s.subject == RDF::URI("http://example.org/xd1")}).to be_truthy
               end
             end
           end
@@ -224,7 +237,7 @@ module RDF_Queryable
         end
 
         it "yields to the given block" do
-          expect {|b| subject.send(:query_execute, query, &b)}.to yield_control.exactly(@queryable.count).times
+          expect {|b| subject.send(:query_execute, query, &b)}.to yield_control.exactly(queryable.count).times
         end
 
         it "yields solutions" do
@@ -248,7 +261,7 @@ module RDF_Queryable
         end
 
         it "yields to the given block" do
-          expect {|b| subject.send(:query_pattern, RDF::Query::Pattern.new, &b)}.to yield_control.exactly(@queryable.count).times
+          expect {|b| subject.send(:query_pattern, RDF::Query::Pattern.new, &b)}.to yield_control.exactly(queryable.count).times
         end
 
         it "yields statements" do
@@ -256,7 +269,7 @@ module RDF_Queryable
             expect(statement).to be_a_statement
           end
         end
-    
+
         context "with specific patterns" do
           # Note that "01" should not match 1, per data-r2/expr-equal/sameTerm
           {

--- a/lib/rdf/spec/readable.rb
+++ b/lib/rdf/spec/readable.rb
@@ -1,16 +1,17 @@
 require 'rdf/spec'
 
-module RDF_Readable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Readable' do
   include RDF::Spec::Matchers
 
-  before :each do
-    raise '+@readable+ must be defined in a before(:each) block' unless instance_variable_get('@readable')
+  before do
+    raise 'readable must be defined in with let(:readable)' unless
+      defined? readable
   end
 
   describe RDF::Readable do
-    subject {@readable}
-    it {should respond_to(:readable?)}
-    its(:readable?) {should == subject.readable?}
+    subject { readable }
+    it { is_expected.to respond_to :readable? }
+    it { is_expected.to respond_to :readable? }
+    its(:readable?) { is_expected.to eq subject.readable? }
   end
 end

--- a/lib/rdf/spec/readable.rb
+++ b/lib/rdf/spec/readable.rb
@@ -15,3 +15,23 @@ RSpec.shared_examples 'an RDF::Readable' do
     its(:readable?) { is_expected.to eq subject.readable? }
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Readable"` instead
+module RDF_Readable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Readable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Readable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Readable' do
+      let(:readable) { @readable }
+
+      before do
+        raise '@readable must be defined' unless defined?(readable)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/reader.rb
+++ b/lib/rdf/spec/reader.rb
@@ -1,208 +1,206 @@
 require 'rdf/spec'
 
-module RDF_Reader
+RSpec.shared_examples 'an RDF::Reader' do
   extend RSpec::SharedContext
-  include RDF::Spec::Matchers
 
   before(:each) do
-    raise '+@reader+ must be defined in a before(:each) block' unless instance_variable_get('@reader')
-    raise '+@reader_input+ must be defined in a before(:each) block' unless instance_variable_get('@reader_input')
-    raise '+@reader_count+ must be defined in a before(:each) block' unless instance_variable_get('@reader_count')
-    @reader_class = @reader.class
+    raise 'reader must be defined with let(:reader)' unless defined? reader
+    raise 'reader_input must be defined with let(:reader_input)' unless defined? reader_input
+    raise 'reader_count must be defined with let(:reader_count)' unless defined? reader_count
   end
 
-  describe RDF::Reader do
-    describe ".each" do
-      it "yields each reader" do
-        @reader_class.each do |r|
-          expect(r).not_to  be_nil
-        end
+  let(:reader_class) { reader.class }
+
+  describe ".each" do
+    it "yields each reader" do
+      reader_class.each do |r|
+        expect(r).not_to  be_nil
       end
     end
+  end
 
-    describe ".open" do
-      before(:each) do
-        allow(RDF::Util::File).to receive(:open_file).and_yield(StringIO.new(@reader_input))
-      end
+  describe ".open" do
+    before(:each) do
+      allow(RDF::Util::File).to receive(:open_file).and_yield(StringIO.new(reader_input))
+    end
 
-      it "yields reader given file_name" do
-        @reader_class.format.each do |f|
-          f.file_extensions.each_pair do |sym, content_type|
-            reader_mock = double("reader")
-            expect(reader_mock).to receive(:got_here)
-            expect(@reader_class).to receive(:for).with(:file_name => "foo.#{sym}").and_return(@reader_class)
-            @reader_class.open("foo.#{sym}") do |r|
-              expect(r).to be_a(RDF::Reader)
-              reader_mock.got_here
-            end
-          end
-        end
-      end
-
-      it "yields reader given symbol" do
-        @reader_class.format.each do |f|
-          sym = f.to_sym  # Like RDF::NTriples::Format => :ntriples
+    it "yields reader given file_name" do
+      reader_class.format.each do |f|
+        f.file_extensions.each_pair do |sym, content_type|
           reader_mock = double("reader")
           expect(reader_mock).to receive(:got_here)
-          expect(@reader_class).to receive(:for).with(sym).and_return(@reader_class)
-          @reader_class.open("foo.#{sym}", :format => sym) do |r|
+          expect(reader_class).to receive(:for).with(:file_name => "foo.#{sym}").and_return(reader_class)
+          reader_class.open("foo.#{sym}") do |r|
             expect(r).to be_a(RDF::Reader)
             reader_mock.got_here
           end
         end
       end
+    end
 
-      it "yields reader given {:file_name => file_name}" do
-        @reader_class.format.each do |f|
-          f.file_extensions.each_pair do |sym, content_type|
-            reader_mock = double("reader")
-            expect(reader_mock).to receive(:got_here)
-            expect(@reader_class).to receive(:for).with(:file_name => "foo.#{sym}").and_return(@reader_class)
-            @reader_class.open("foo.#{sym}", :file_name => "foo.#{sym}") do |r|
-              expect(r).to be_a(RDF::Reader)
-              reader_mock.got_here
-            end
+    it "yields reader given symbol" do
+      reader_class.format.each do |f|
+        sym = f.to_sym  # Like RDF::NTriples::Format => :ntriples
+        reader_mock = double("reader")
+        expect(reader_mock).to receive(:got_here)
+        expect(reader_class).to receive(:for).with(sym).and_return(reader_class)
+        reader_class.open("foo.#{sym}", :format => sym) do |r|
+          expect(r).to be_a(RDF::Reader)
+          reader_mock.got_here
+        end
+      end
+    end
+
+    it "yields reader given {:file_name => file_name}" do
+      reader_class.format.each do |f|
+        f.file_extensions.each_pair do |sym, content_type|
+          reader_mock = double("reader")
+          expect(reader_mock).to receive(:got_here)
+          expect(reader_class).to receive(:for).with(:file_name => "foo.#{sym}").and_return(reader_class)
+          reader_class.open("foo.#{sym}", :file_name => "foo.#{sym}") do |r|
+            expect(r).to be_a(RDF::Reader)
+            reader_mock.got_here
           end
         end
       end
+    end
 
-      it "yields reader given {:content_type => 'a/b'}" do
-        @reader_class.format.each do |f|
-          f.content_types.each_pair do |content_type, formats|
-            reader_mock = double("reader")
-            expect(reader_mock).to receive(:got_here)
-            expect(@reader_class).to receive(:for).with(:content_type => content_type, :file_name => "foo").and_return(@reader_class)
-            @reader_class.open("foo", :content_type => content_type) do |r|
-              expect(r).to be_a(RDF::Reader)
-              reader_mock.got_here
-            end
+    it "yields reader given {:content_type => 'a/b'}" do
+      reader_class.format.each do |f|
+        f.content_types.each_pair do |content_type, formats|
+          reader_mock = double("reader")
+          expect(reader_mock).to receive(:got_here)
+          expect(reader_class).to receive(:for).with(:content_type => content_type, :file_name => "foo").and_return(reader_class)
+          reader_class.open("foo", :content_type => content_type) do |r|
+            expect(r).to be_a(RDF::Reader)
+            reader_mock.got_here
           end
         end
       end
     end
+  end
 
-    describe ".format" do
-      it "returns itself even if given explicit format" do
-        other_format = @reader_class == RDF::NTriples::Reader ? :nquads : :ntriples
-        expect(@reader_class.for(other_format)).to eq @reader_class
+  describe ".format" do
+    it "returns itself even if given explicit format" do
+      other_format = reader_class == RDF::NTriples::Reader ? :nquads : :ntriples
+      expect(reader_class.for(other_format)).to eq reader_class
+    end
+  end
+
+  describe ".new" do
+    it "sets @input to StringIO given a string" do
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      reader_class.new(reader_input) do |r|
+        reader_mock.got_here
+        expect(r.instance_variable_get(:@input)).to be_a(StringIO)
       end
     end
 
-    describe ".new" do
-      it "sets @input to StringIO given a string" do
-        reader_mock = double("reader")
-        expect(reader_mock).to receive(:got_here)
-        @reader_class.new(@reader_input) do |r|
-          reader_mock.got_here
-          expect(r.instance_variable_get(:@input)).to be_a(StringIO)
-        end
-      end
-
-      it "sets @input to input given something other than a string" do
-        reader_mock = double("reader")
-        expect(reader_mock).to receive(:got_here)
-        file = StringIO.new(@reader_input)
-        @reader_class.new(file) do |r|
-          reader_mock.got_here
-          expect(r.instance_variable_get(:@input)).to eq file
-        end
-      end
-
-      it "sets validate given :validate => true" do
-        @reader_class.new(@reader_input, :validate => true) do |r|
-          expect(r).to be_valid
-        end
-      end
-    
-      it "sets canonicalize given :canonicalize => true" do
-        reader_mock = double("reader")
-        expect(reader_mock).to receive(:got_here)
-        @reader_class.new(@reader_input, :canonicalize => true) do |r|
-          reader_mock.got_here
-          expect(r).to be_canonicalize
-        end
-      end
-    
-      it "sets intern given :intern => true" do
-        reader_mock = double("reader")
-        expect(reader_mock).to receive(:got_here)
-        @reader_class.new(@reader_input, :intern => true) do |r|
-          reader_mock.got_here
-          expect(r).to be_intern
-        end
-      end
-    
-      it "sets prefixes given :prefixes => {}" do
-        reader_mock = double("reader")
-        expect(reader_mock).to receive(:got_here)
-        @reader_class.new(@reader_input, :prefixes => {:a => "b"}) do |r|
-          reader_mock.got_here
-          expect(r.prefixes).to eq({:a => "b"})
-        end
-      end
-    end
-  
-    describe "#prefixes=" do
-      it "sets prefixes from hash" do
-        @reader.prefixes = {:a => "b"}
-        expect(@reader.prefixes).to eq({:a => "b"})
-      end
-    end
-  
-    describe "#prefix" do
-      {
-        nil     => "nil",
-        :a      => "b",
-        "foo"   => "bar",
-      }.each_pair do |pfx, uri|
-        it "sets prefix(#{pfx}) to #{uri}" do
-          expect(@reader.prefix(pfx, uri)).to eq uri
-          expect(@reader.prefix(pfx)).to eq uri
-        end
+    it "sets @input to input given something other than a string" do
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      file = StringIO.new(reader_input)
+      reader_class.new(file) do |r|
+        reader_mock.got_here
+        expect(r.instance_variable_get(:@input)).to eq file
       end
     end
 
-    context RDF::Enumerable do
-      it "#count" do
-        @reader_class.new(@reader_input) {|r| expect(r.count).to eq @reader_count}
+    it "sets validate given :validate => true" do
+      reader_class.new(reader_input, :validate => true) do |r|
+        expect(r).to be_valid
       end
-      it "#empty?" do
-        @reader_class.new(@reader_input) {|r| expect(r).not_to be_empty}
-      end
-
-      it "#statements" do
-        @reader_class.new(@reader_input) {|r| expect(r.statements.count).to eq @reader_count}
-      end
-      it "#has_statement?" do
-        @reader_class.new(@reader_input) {|r| expect(r).to respond_to(:has_statement?)}
-      end
-      it "#each_statement" do
-        @reader_class.new(@reader_input) {|r| expect(r.each_statement.count).to eq @reader_count}
-      end
-      it "#enum_statement" do
-        @reader_class.new(@reader_input) {|r| expect(r.enum_statement.count).to eq @reader_count}
-      end
-
-      it "#triples" do
-        @reader_class.new(@reader_input) {|r| expect(r.triples.count).to eq @reader_count}
-      end
-      it "#each_triple" do
-        @reader_class.new(@reader_input) {|r| expect(r.each_triple.count).to eq @reader_count}
-      end
-      it "#enum_triple" do
-        @reader_class.new(@reader_input) {|r| expect(r.enum_triple.count).to eq @reader_count}
-      end
-
-      it "#quads" do
-        @reader_class.new(@reader_input) {|r| expect(r.quads.count).to eq @reader_count}
-      end
-      it "#each_quad" do
-        @reader_class.new(@reader_input) {|r| expect(r.each_quad.count).to eq @reader_count}
-      end
-      it "#enum_quad" do
-        @reader_class.new(@reader_input) {|r| expect(r.enum_quad.count).to eq @reader_count}
-      end
-
     end
+
+    it "sets canonicalize given :canonicalize => true" do
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      reader_class.new(reader_input, :canonicalize => true) do |r|
+        reader_mock.got_here
+        expect(r).to be_canonicalize
+      end
+    end
+
+    it "sets intern given :intern => true" do
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      reader_class.new(reader_input, :intern => true) do |r|
+        reader_mock.got_here
+        expect(r).to be_intern
+      end
+    end
+
+    it "sets prefixes given :prefixes => {}" do
+      reader_mock = double("reader")
+      expect(reader_mock).to receive(:got_here)
+      reader_class.new(reader_input, :prefixes => {:a => "b"}) do |r|
+        reader_mock.got_here
+        expect(r.prefixes).to eq({:a => "b"})
+      end
+    end
+  end
+
+  describe "#prefixes=" do
+    it "sets prefixes from hash" do
+      reader.prefixes = {:a => "b"}
+      expect(reader.prefixes).to eq({:a => "b"})
+    end
+  end
+
+  describe "#prefix" do
+    {
+      nil     => "nil",
+      :a      => "b",
+      "foo"   => "bar",
+    }.each_pair do |pfx, uri|
+      it "sets prefix(#{pfx}) to #{uri}" do
+        expect(reader.prefix(pfx, uri)).to eq uri
+        expect(reader.prefix(pfx)).to eq uri
+      end
+    end
+  end
+
+  context RDF::Enumerable do
+    it "#count" do
+      reader_class.new(reader_input) {|r| expect(r.count).to eq reader_count}
+    end
+    it "#empty?" do
+      reader_class.new(reader_input) {|r| expect(r).not_to be_empty}
+    end
+
+    it "#statements" do
+      reader_class.new(reader_input) {|r| expect(r.statements.count).to eq reader_count}
+    end
+    it "#has_statement?" do
+      reader_class.new(reader_input) {|r| expect(r).to respond_to(:has_statement?)}
+    end
+    it "#each_statement" do
+      reader_class.new(reader_input) {|r| expect(r.each_statement.count).to eq reader_count}
+    end
+    it "#enum_statement" do
+      reader_class.new(reader_input) {|r| expect(r.enum_statement.count).to eq reader_count}
+    end
+
+    it "#triples" do
+      reader_class.new(reader_input) {|r| expect(r.triples.count).to eq reader_count}
+    end
+    it "#each_triple" do
+      reader_class.new(reader_input) {|r| expect(r.each_triple.count).to eq reader_count}
+    end
+    it "#enum_triple" do
+      reader_class.new(reader_input) {|r| expect(r.enum_triple.count).to eq reader_count}
+    end
+
+    it "#quads" do
+      reader_class.new(reader_input) {|r| expect(r.quads.count).to eq reader_count}
+    end
+    it "#each_quad" do
+      reader_class.new(reader_input) {|r| expect(r.each_quad.count).to eq reader_count}
+    end
+    it "#enum_quad" do
+      reader_class.new(reader_input) {|r| expect(r.enum_quad.count).to eq reader_count}
+    end
+
   end
 end

--- a/lib/rdf/spec/reader.rb
+++ b/lib/rdf/spec/reader.rb
@@ -204,3 +204,29 @@ RSpec.shared_examples 'an RDF::Reader' do
 
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Reader"` instead
+module RDF_Reader
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Reader` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Reader'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Reader' do
+      let(:reader) { @reader }
+      let(:reader_input) { @reader_input }
+      let(:reader_count) { @reader_count }
+      let(:reader_class) { @reader_class }
+
+      before do
+        raise '@reader must be defined' unless defined?(reader)
+        raise '@reader_input must be defined' unless defined?(reader_input)
+        raise '@reader_count must be defined' unless defined?(reader_count)
+        raise '@reader_class must be defined' unless defined?(reader_class)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -56,3 +56,23 @@ RSpec.shared_examples 'an RDF::Repository' do
     it_behaves_like 'an RDF::Durable'
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Repository"` instead
+module RDF_Repository
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Repository` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Repository'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Repository' do
+      let(:repository) { @repository }
+
+      before do
+        raise '@repository must be defined' unless defined?(repository)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -1,59 +1,58 @@
 require 'rdf/spec'
 
-module RDF_Repository
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Repository' do
   include RDF::Spec::Matchers
 
   before :each do
-    raise '+@repository+ must be defined in a before(:each) block' unless instance_variable_get('@repository')
+    raise 'repository must be set with `let(:repository)' unless
+      defined? repository
+
     @statements = RDF::Spec.quads
-    if @repository.empty? && @repository.writable?
-      @repository.insert(*@statements)
-    elsif @repository.empty?
+    if repository.empty? && repository.writable?
+      repository.insert(*@statements)
+    elsif repository.empty?
       raise "+@repository+ must respond to #<< or be pre-populated with the statements in #{RDF::Spec::TRIPLES_FILE} in a before(:each) block"
     end
-    @countable = @repository
-    @enumerable = @repository
-    @queryable = @repository
-    @mutable = @repository
   end
 
-  describe RDF::Repository do
+  let(:countable) { repository }
+  let(:enumerable) { repository }
+  let(:queryable) { repository }
+  let(:mutable) { repository }
 
-    context "when counting statements" do
-      require 'rdf/spec/countable'
-      include RDF_Countable
+  context "when counting statements" do
+    require 'rdf/spec/countable'
+    it_behaves_like 'an RDF::Countable'
+  end
+
+  context "when enumerating statements" do
+    require 'rdf/spec/enumerable'
+    it_behaves_like 'an RDF::Enumerable'
+  end
+
+  context "when querying statements" do
+    require 'rdf/spec/queryable'
+    it_behaves_like 'an RDF::Queryable'
+  end
+
+  # FIXME: This should be condition on the repository being mutable
+  context "when updating" do
+    require 'rdf/spec/mutable'
+
+    before { mutable.clear }
+
+    it_behaves_like 'an RDF::Mutable'
+  end
+
+  # FIXME: This should be condition on the repository being mutable
+  context "as a durable repository" do
+    require 'rdf/spec/durable'
+
+    before :each do
+      repository.clear
+      @load_durable ||= lambda { repository }
     end
 
-    context "when enumerating statements" do
-      require 'rdf/spec/enumerable'
-      include RDF_Enumerable
-    end
-
-    context "when querying statements" do
-      require 'rdf/spec/queryable'
-      include RDF_Queryable
-    end
-
-    # FIXME: This should be condition on the repository being mutable
-    context "when updating" do
-      require 'rdf/spec/mutable'
-      before(:each) do
-        @mutable.clear
-      end
-      include RDF_Mutable
-    end
-
-    # FIXME: This should be condition on the repository being mutable
-    context "as a durable repository" do
-      require 'rdf/spec/durable'
-
-      before :each do
-        @repository.clear
-        @load_durable ||= lambda { @repository }
-      end
-
-      include RDF_Durable
-    end
+    it_behaves_like 'an RDF::Durable'
   end
 end

--- a/lib/rdf/spec/transaction.rb
+++ b/lib/rdf/spec/transaction.rb
@@ -2,109 +2,107 @@ require 'rdf/spec'
 
 # Pass in an instance of RDF::Transaction as follows:
 #
-#   it_behaves_like "RDF_Transaction", RDF::Transaction
-shared_examples "RDF_Transaction" do |klass|
+#   it_behaves_like "RDF::Transaction", RDF::Transaction
+shared_examples "RDF::Transaction" do |klass|
   include RDF::Spec::Matchers
 
-  describe RDF::Transaction do
-    subject {klass.new(:context => RDF::URI("name"), :insert => RDF::Graph.new, :delete => RDF::Graph.new)}
+  subject {klass.new(:context => RDF::URI("name"), :insert => RDF::Graph.new, :delete => RDF::Graph.new)}
 
-    describe "#initialize" do
-      subject {klass}
-      it "accepts a graph" do
-        g = double("graph")
-        this = subject.new(:graph => g)
-        expect(this.graph).to eq g
-      end
-
-      it "accepts a context" do
-        c = double("context")
-        this = subject.new(:graph => c)
-        expect(this.graph).to eq c
-        expect(this.context).to eq c
-
-        this = subject.new(:context => c)
-        expect(this.graph).to eq c
-        expect(this.context).to eq c
-      end
-
-      it "accepts inserts" do
-        g = double("inserts")
-        this = subject.new(:insert => g)
-        expect(this.inserts).to eq g
-      end
-
-      it "accepts deletes" do
-        g = double("deletes")
-        this = subject.new(:delete => g)
-        expect(this.deletes).to eq g
-      end
+  describe "#initialize" do
+    subject {klass}
+    it "accepts a graph" do
+      g = double("graph")
+      this = subject.new(:graph => g)
+      expect(this.graph).to eq g
     end
 
-    its(:deletes) {should be_a(RDF::Enumerable)}
-    its(:inserts) {should be_a(RDF::Enumerable)}
-    it {should be_mutable}
-    it {should_not be_readable}
+    it "accepts a context" do
+      c = double("context")
+      this = subject.new(:graph => c)
+      expect(this.graph).to eq c
+      expect(this.context).to eq c
 
-    it "does not respond to #load" do
-      expect {subject.load("http://example/")}.to raise_error(NoMethodError)
+      this = subject.new(:context => c)
+      expect(this.graph).to eq c
+      expect(this.context).to eq c
     end
 
-    it "does not respond to #update" do
-      expect {subject.update(RDF::Statement.new)}.to raise_error(NoMethodError)
+    it "accepts inserts" do
+      g = double("inserts")
+      this = subject.new(:insert => g)
+      expect(this.inserts).to eq g
     end
 
-    it "does not respond to #clear" do
-      expect {subject.clear}.to raise_error(NoMethodError)
+    it "accepts deletes" do
+      g = double("deletes")
+      this = subject.new(:delete => g)
+      expect(this.deletes).to eq g
+    end
+  end
+
+  its(:deletes) {should be_a(RDF::Enumerable)}
+  its(:inserts) {should be_a(RDF::Enumerable)}
+  it {should be_mutable}
+  it {should_not be_readable}
+
+  it "does not respond to #load" do
+    expect {subject.load("http://example/")}.to raise_error(NoMethodError)
+  end
+
+  it "does not respond to #update" do
+    expect {subject.update(RDF::Statement.new)}.to raise_error(NoMethodError)
+  end
+
+  it "does not respond to #clear" do
+    expect {subject.clear}.to raise_error(NoMethodError)
+  end
+
+  describe "#execute" do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+    let(:r) {double("repository")}
+
+    it "deletes statements" do
+      expect(r).to receive(:delete).with(s)
+      expect(r).not_to receive(:insert)
+      subject.delete(s)
+      subject.execute(r)
     end
 
-    describe "#execute" do
-      let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
-      let(:r) {double("repository")}
-
-      it "deletes statements" do
-        expect(r).to receive(:delete).with(s)
-        expect(r).not_to receive(:insert)
-        subject.delete(s)
-        subject.execute(r)
-      end
-
-      it "inserts statements" do
-        expect(r).not_to receive(:delete)
-        expect(r).to receive(:insert).with(s)
-        subject.insert(s)
-        subject.execute(r)
-      end
-
-      it "calls before_execute" do
-        expect(subject).to receive(:before_execute).with(r, {})
-        subject.execute(r)
-      end
-
-      it "calls after_execute" do
-        expect(subject).to receive(:after_execute).with(r, {})
-        subject.execute(r)
-      end
-
-      it "returns self" do
-        expect(subject.execute(r)).to eq subject
-      end
+    it "inserts statements" do
+      expect(r).not_to receive(:delete)
+      expect(r).to receive(:insert).with(s)
+      subject.insert(s)
+      subject.execute(r)
     end
-  
-    describe "#delete_statement" do
-      let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
-      it "adds statement to #deletes" do
-        subject.delete(s)
-        expect(subject.deletes.to_a).to eq [s]
-      end
+
+    it "calls before_execute" do
+      expect(subject).to receive(:before_execute).with(r, {})
+      subject.execute(r)
     end
-  
-    describe "#insert_statement" do
-      let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
-      it "adds statement to #inserts" do
-        subject.insert(s)
-        expect(subject.inserts.to_a).to eq [s]
-      end
+
+    it "calls after_execute" do
+      expect(subject).to receive(:after_execute).with(r, {})
+      subject.execute(r)
+    end
+
+    it "returns self" do
+      expect(subject.execute(r)).to eq subject
+    end
+  end
+
+  describe "#delete_statement" do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+    it "adds statement to #deletes" do
+      subject.delete(s)
+      expect(subject.deletes.to_a).to eq [s]
+    end
+  end
+
+  describe "#insert_statement" do
+    let(:s) {RDF::Statement.new(RDF::URI("s"), RDF::URI("p"), RDF::URI("o"))}
+    it "adds statement to #inserts" do
+      subject.insert(s)
+      expect(subject.inserts.to_a).to eq [s]
     end
   end
 end

--- a/lib/rdf/spec/transaction.rb
+++ b/lib/rdf/spec/transaction.rb
@@ -3,7 +3,7 @@ require 'rdf/spec'
 # Pass in an instance of RDF::Transaction as follows:
 #
 #   it_behaves_like "RDF::Transaction", RDF::Transaction
-shared_examples "RDF::Transaction" do |klass|
+shared_examples "an RDF::Transaction" do |klass|
   include RDF::Spec::Matchers
 
   subject {klass.new(:context => RDF::URI("name"), :insert => RDF::Graph.new, :delete => RDF::Graph.new)}
@@ -105,4 +105,8 @@ shared_examples "RDF::Transaction" do |klass|
       expect(subject.inserts.to_a).to eq [s]
     end
   end
+end
+
+shared_examples "RDF_Transaction" do |klass|
+  it_behaves_like 'an RDF::Transaction', klass
 end

--- a/lib/rdf/spec/writable.rb
+++ b/lib/rdf/spec/writable.rb
@@ -1,26 +1,26 @@
 require 'rdf/spec'
 
-module RDF_Writable
-  extend RSpec::SharedContext
+RSpec.shared_examples 'an RDF::Writable' do
   include RDF::Spec::Matchers
 
   before :each do
-    raise '+@writable+ must be defined in a before(:each) block' unless instance_variable_get('@writable')
+    raise 'writable must be defined in with let(:readable)' unless
+      defined? writable
 
     @filename = RDF::Spec::TRIPLES_FILE
     @statements = RDF::NTriples::Reader.new(File.open(@filename)).to_a
 
-    @supports_context = @writable.respond_to?(:supports?) && @writable.supports?(:context)
+    @supports_context = writable.respond_to?(:supports?) && writable.supports?(:context)
   end
 
   describe RDF::Writable do
-    subject {@writable}
+    subject { writable }
     let(:statement) {@statements.detect {|s| s.to_a.all? {|r| r.uri?}}}
     let(:count) {@statements.size}
 
     it {should respond_to(:writable?)}
     its(:writable?) {should == !!subject.writable?}
-  
+
     describe "#<<" do
       it "inserts a reader" do
         skip("writability") unless subject.writable?

--- a/lib/rdf/spec/writable.rb
+++ b/lib/rdf/spec/writable.rb
@@ -13,104 +13,122 @@ RSpec.shared_examples 'an RDF::Writable' do
     @supports_context = writable.respond_to?(:supports?) && writable.supports?(:context)
   end
 
-  describe RDF::Writable do
-    subject { writable }
-    let(:statement) {@statements.detect {|s| s.to_a.all? {|r| r.uri?}}}
-    let(:count) {@statements.size}
+  subject { writable }
+  let(:statement) {@statements.detect {|s| s.to_a.all? {|r| r.uri?}}}
+  let(:count) {@statements.size}
 
-    it {should respond_to(:writable?)}
-    its(:writable?) {should == !!subject.writable?}
+  it {should respond_to(:writable?)}
+  its(:writable?) {should == !!subject.writable?}
 
-    describe "#<<" do
-      it "inserts a reader" do
-        skip("writability") unless subject.writable?
-        reader = RDF::NTriples::Reader.new(File.open(@filename)).to_a
-        subject << reader
-        expect(subject).to have_statement(statement)
-        expect(subject.count).to eq count
-      end
-
-      it "inserts a graph" do
-        skip("writability") unless subject.writable?
-        graph = RDF::Graph.new << @statements
-        subject << graph
-        expect(subject).to have_statement(statement)
-        expect(subject.count).to eq count
-      end
-
-      it "inserts an enumerable" do
-        skip("writability") unless subject.writable?
-        enumerable = @statements.dup.extend(RDF::Enumerable)
-        subject << enumerable
-        expect(subject).to have_statement(statement)
-        expect(subject.count).to eq count
-      end
-
-      it "inserts data responding to #to_rdf" do
-        skip("writability") unless subject.writable?
-        mock = double('mock')
-        allow(mock).to receive(:to_rdf).and_return(@statements)
-        subject << mock
-        expect(subject).to have_statement(statement)
-        expect(subject.count).to eq count
-      end
-
-      it "inserts a statement" do
-        skip("writability") unless subject.writable?
-        subject << statement
-        expect(subject).to have_statement(statement)
-        expect(subject.count).to eq 1
-      end
+  describe "#<<" do
+    it "inserts a reader" do
+      skip("writability") unless subject.writable?
+      reader = RDF::NTriples::Reader.new(File.open(@filename)).to_a
+      subject << reader
+      expect(subject).to have_statement(statement)
+      expect(subject.count).to eq count
     end
 
-    context "when inserting statements" do
-      it "should support #insert" do
-        skip("writability") unless subject.writable?
-        expect(subject).to respond_to(:insert)
-      end
+    it "inserts a graph" do
+      skip("writability") unless subject.writable?
+      graph = RDF::Graph.new << @statements
+      subject << graph
+      expect(subject).to have_statement(statement)
+      expect(subject.count).to eq count
+    end
 
-      it "should not raise errors" do
-        skip("writability") unless subject.writable?
-        expect { subject.insert(statement) }.not_to raise_error
-      end
+    it "inserts an enumerable" do
+      skip("writability") unless subject.writable?
+      enumerable = @statements.dup.extend(RDF::Enumerable)
+      subject << enumerable
+      expect(subject).to have_statement(statement)
+      expect(subject.count).to eq count
+    end
 
-      it "should support inserting one statement at a time" do
-        skip("writability") unless subject.writable?
-        subject.insert(statement)
-        expect(subject).to have_statement(statement)
-      end
+    it "inserts data responding to #to_rdf" do
+      skip("writability") unless subject.writable?
+      mock = double('mock')
+      allow(mock).to receive(:to_rdf).and_return(@statements)
+      subject << mock
+      expect(subject).to have_statement(statement)
+      expect(subject.count).to eq count
+    end
 
-      it "should support inserting multiple statements at a time" do
-        skip("writability") unless subject.writable?
-        subject.insert(*@statements)
-      end
+    it "inserts a statement" do
+      skip("writability") unless subject.writable?
+      subject << statement
+      expect(subject).to have_statement(statement)
+      expect(subject.count).to eq 1
+    end
+  end
 
-      it "should insert statements successfully" do
-        skip("writability") unless subject.writable?
-        subject.insert(*@statements)
-        expect(subject.count).to eq count
-      end
+  context "when inserting statements" do
+    it "should support #insert" do
+      skip("writability") unless subject.writable?
+      expect(subject).to respond_to(:insert)
+    end
 
-      it "should not insert a statement twice" do
-        skip("writability") unless subject.writable?
-        subject.insert(statement)
-        subject.insert(statement)
-        expect(subject.count).to eq 1
-      end
+    it "should not raise errors" do
+      skip("writability") unless subject.writable?
+      expect { subject.insert(statement) }.not_to raise_error
+    end
 
-      it "should treat statements with a different context as distinct" do
-        skip("writability") unless subject.writable?
-        s1 = statement.dup
-        s1.context = nil
-        s2 = statement.dup
-        s2.context = RDF::URI.new("urn:context:1")
-        s3 = statement.dup
-        s3.context = RDF::URI.new("urn:context:2")
-        subject.insert(s1)
-        subject.insert(s2)
-        subject.insert(s3)
-        # If contexts are not suported, all three are redundant
-        expect(subject.count).to eq (@supports_context ? 3 : 1)
+    it "should support inserting one statement at a time" do
+      skip("writability") unless subject.writable?
+      subject.insert(statement)
+      expect(subject).to have_statement(statement)
+    end
+
+    it "should support inserting multiple statements at a time" do
+      skip("writability") unless subject.writable?
+      subject.insert(*@statements)
+    end
+
+    it "should insert statements successfully" do
+      skip("writability") unless subject.writable?
+      subject.insert(*@statements)
+      expect(subject.count).to eq count
+    end
+
+    it "should not insert a statement twice" do
+      skip("writability") unless subject.writable?
+      subject.insert(statement)
+      subject.insert(statement)
+      expect(subject.count).to eq 1
+    end
+
+    it "should treat statements with a different context as distinct" do
+      skip("writability") unless subject.writable?
+      s1 = statement.dup
+      s1.context = nil
+      s2 = statement.dup
+      s2.context = RDF::URI.new("urn:context:1")
+      s3 = statement.dup
+      s3.context = RDF::URI.new("urn:context:2")
+      subject.insert(s1)
+      subject.insert(s2)
+      subject.insert(s3)
+      # If contexts are not suported, all three are redundant
+      expect(subject.count).to eq (@supports_context ? 3 : 1)
+    end
+  end
+end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Writable"` instead
+module RDF_Writable
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Writable` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Writable'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Writable' do
+      let(:writable) { @writable }
+
+      before do
+        raise '@writable must be defined' unless defined?(writable)
       end
     end
   end

--- a/lib/rdf/spec/writer.rb
+++ b/lib/rdf/spec/writer.rb
@@ -173,3 +173,25 @@ RSpec.shared_examples 'an RDF::Writer' do
     end
   end
 end
+
+##
+# @deprecated use `it_behaves_like "an RDF::Writer"` instead
+module RDF_Writer
+  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
+
+  warn "[DEPRECATION] `RDF_Writer` is deprecated. "\
+       "Please use `it_behaves_like 'an RDF::Writer'`"
+
+  describe 'examples for' do
+    include_examples 'an RDF::Writer' do
+      let(:writer_class) { @writer_class }
+      let(:writer) { @writer }
+
+      before do
+        raise '@writer_class must be defined' unless defined?(writer_class)
+        raise '@writer must be defined' unless defined?(writer)
+      end
+    end
+  end
+end

--- a/lib/rdf/spec/writer.rb
+++ b/lib/rdf/spec/writer.rb
@@ -2,175 +2,173 @@ require 'rdf/spec'
 require 'fileutils'
 require 'tmpdir'
 
-module RDF_Writer
+RSpec.shared_examples 'an RDF::Writer' do
   extend RSpec::SharedContext
-  include RDF::Spec::Matchers
 
   before(:each) do
-    raise '+@writer+ must be defined in a before(:each) block' unless instance_variable_get('@writer')
-    @writer_class = @writer.class
+    raise 'writer must be defined with let(:writer)' unless
+      defined? writer
+  end
+  let(:writer_class) { writer.class }
+
+  describe ".each" do
+    it "yields each writer" do
+      writer_class.each do |r|
+        expect(r).not_to be_nil
+      end
+    end
   end
 
-  describe RDF::Writer do
-    describe ".each" do
-      it "yields each writer" do
-        @writer_class.each do |r|
-          expect(r).not_to be_nil
-        end
+  describe ".buffer" do
+    it "calls .new with buffer and other arguments" do
+      expect(writer_class).to receive(:new)
+      writer_class.buffer do |r|
+        expect(r).to be_a(writer_class)
       end
     end
-  
-    describe ".buffer" do
-      it "calls .new with buffer and other arguments" do
-        expect(@writer_class).to receive(:new)
-        @writer_class.buffer do |r|
-          expect(r).to be_a(@writer_class)
-        end
-      end
+  end
+
+  describe ".open" do
+    before(:each) do
+      allow(RDF::Util::File).to receive(:open_file).and_yield(StringIO.new("foo"))
+      @dir = Dir.mktmpdir
+      @basename = File.join(@dir, "foo")
     end
 
-    describe ".open" do
-      before(:each) do
-        allow(RDF::Util::File).to receive(:open_file).and_yield(StringIO.new("foo"))
-        @dir = Dir.mktmpdir
-        @basename = File.join(@dir, "foo")
-      end
-    
-      after(:each) do
-        FileUtils.rm_rf(@dir)
-      end
+    after(:each) do
+      FileUtils.rm_rf(@dir)
+    end
 
-      it "yields writer given file_name" do
-        @writer_class.format.each do |f|
-          f.file_extensions.each_pair do |sym, content_type|
-            writer_mock = double("writer")
-            expect(writer_mock).to receive(:got_here)
-            expect(@writer_class).to receive(:for).with(:file_name => "#{@basename}.#{sym}").and_return(@writer_class)
-            @writer_class.open("#{@basename}.#{sym}") do |r|
-              expect(r).to be_a(RDF::Writer)
-              writer_mock.got_here
-            end
-          end
-        end
-      end
-
-      it "yields writer given symbol" do
-        @writer_class.format.each do |f|
-          sym = f.to_sym  # Like RDF::NTriples::Format => :ntriples
+    it "yields writer given file_name" do
+      writer_class.format.each do |f|
+        f.file_extensions.each_pair do |sym, content_type|
           writer_mock = double("writer")
           expect(writer_mock).to receive(:got_here)
-          expect(@writer_class).to receive(:for).with(sym).and_return(@writer_class)
-          @writer_class.open("#{@basename}.#{sym}", :format => sym) do |r|
+          expect(writer_class).to receive(:for).with(:file_name => "#{@basename}.#{sym}").and_return(writer_class)
+          writer_class.open("#{@basename}.#{sym}") do |r|
             expect(r).to be_a(RDF::Writer)
             writer_mock.got_here
           end
         end
       end
+    end
 
-      it "yields writer given {:file_name => file_name}" do
-        @writer_class.format.each do |f|
-          f.file_extensions.each_pair do |sym, content_type|
-            writer_mock = double("writer")
-            expect(writer_mock).to receive(:got_here)
-            expect(@writer_class).to receive(:for).with(:file_name => "#{@basename}.#{sym}").and_return(@writer_class)
-            @writer_class.open("#{@basename}.#{sym}", :file_name => "#{@basename}.#{sym}") do |r|
-              expect(r).to be_a(RDF::Writer)
-              writer_mock.got_here
-            end
+    it "yields writer given symbol" do
+      writer_class.format.each do |f|
+        sym = f.to_sym  # Like RDF::NTriples::Format => :ntriples
+        writer_mock = double("writer")
+        expect(writer_mock).to receive(:got_here)
+        expect(writer_class).to receive(:for).with(sym).and_return(writer_class)
+        writer_class.open("#{@basename}.#{sym}", :format => sym) do |r|
+          expect(r).to be_a(RDF::Writer)
+          writer_mock.got_here
+        end
+      end
+    end
+
+    it "yields writer given {:file_name => file_name}" do
+      writer_class.format.each do |f|
+        f.file_extensions.each_pair do |sym, content_type|
+          writer_mock = double("writer")
+          expect(writer_mock).to receive(:got_here)
+          expect(writer_class).to receive(:for).with(:file_name => "#{@basename}.#{sym}").and_return(writer_class)
+          writer_class.open("#{@basename}.#{sym}", :file_name => "#{@basename}.#{sym}") do |r|
+            expect(r).to be_a(RDF::Writer)
+            writer_mock.got_here
           end
         end
       end
+    end
 
-      it "yields writer given {:content_type => 'a/b'}" do
-        @writer_class.format.each do |f|
-          f.content_types.each_pair do |content_type, formats|
-            writer_mock = double("writer")
-            expect(writer_mock).to receive(:got_here)
-            expect(@writer_class).to receive(:for).with(:content_type => content_type, :file_name => @basename).and_return(@writer_class)
-            @writer_class.open(@basename, :content_type => content_type) do |r|
-              expect(r).to be_a(RDF::Writer)
-              writer_mock.got_here
-            end
+    it "yields writer given {:content_type => 'a/b'}" do
+      writer_class.format.each do |f|
+        f.content_types.each_pair do |content_type, formats|
+          writer_mock = double("writer")
+          expect(writer_mock).to receive(:got_here)
+          expect(writer_class).to receive(:for).with(:content_type => content_type, :file_name => @basename).and_return(writer_class)
+          writer_class.open(@basename, :content_type => content_type) do |r|
+            expect(r).to be_a(RDF::Writer)
+            writer_mock.got_here
           end
         end
       end
     end
+  end
 
-    describe ".format" do
-      it "returns itself even if given explicit format" do
-        other_format = @writer_class == RDF::NTriples::Writer ? :nquads : :ntriples
-        expect(@writer_class.for(other_format)).to eq @writer_class
+  describe ".format" do
+    it "returns itself even if given explicit format" do
+      other_format = writer_class == RDF::NTriples::Writer ? :nquads : :ntriples
+      expect(writer_class.for(other_format)).to eq writer_class
+    end
+  end
+
+  describe ".new" do
+    it "sets @output to $stdout by default" do
+      writer_mock = double("writer")
+      expect(writer_mock).to receive(:got_here)
+      save, $stdout = $stdout, StringIO.new
+
+      writer_class.new do |r|
+        writer_mock.got_here
+        expect(r.instance_variable_get(:@output)).to eq $stdout
+      end
+      $stdout = save
+    end
+
+    it "sets @output to file given something other than a string" do
+      writer_mock = double("writer")
+      expect(writer_mock).to receive(:got_here)
+      file = StringIO.new
+      writer_class.new(file) do |r|
+        writer_mock.got_here
+        expect(r.instance_variable_get(:@output)).to eq file
       end
     end
 
-    describe ".new" do
-      it "sets @output to $stdout by default" do
-        writer_mock = double("writer")
-        expect(writer_mock).to receive(:got_here)
-        save, $stdout = $stdout, StringIO.new
+    it "sets prefixes given :prefixes => {}" do
+      writer_mock = double("writer")
+      expect(writer_mock).to receive(:got_here)
+      writer_class.new(StringIO.new, :prefixes => {:a => "b"}) do |r|
+        writer_mock.got_here
+        expect(r.prefixes).to eq({:a => "b"})
+      end
+    end
 
-        @writer_class.new do |r|
-          writer_mock.got_here
-          expect(r.instance_variable_get(:@output)).to eq $stdout
-        end
-        $stdout = save
-      end
-    
-      it "sets @output to file given something other than a string" do
-        writer_mock = double("writer")
-        expect(writer_mock).to receive(:got_here)
-        file = StringIO.new
-        @writer_class.new(file) do |r|
-          writer_mock.got_here
-          expect(r.instance_variable_get(:@output)).to eq file
-        end
-      end
-    
-      it "sets prefixes given :prefixes => {}" do
-        writer_mock = double("writer")
-        expect(writer_mock).to receive(:got_here)
-        @writer_class.new(StringIO.new, :prefixes => {:a => "b"}) do |r|
-          writer_mock.got_here
-          expect(r.prefixes).to eq({:a => "b"})
-        end
-      end
-    
-      #it "calls #write_prologue" do
-      #  writer_mock = double("writer")
-      #  writer_mock.should_receive(:got_here)
-      #  @writer_class.any_instance.should_receive(:write_prologue)
-      #  @writer_class.new(StringIO.new) do |r|
-      #    writer_mock.got_here
-      #  end
-      #end
-      #
-      #it "calls #write_epilogue" do
-      #  writer_mock = double("writer")
-      #  writer_mock.should_receive(:got_here)
-      #  @writer_class.any_instance.should_receive(:write_epilogue)
-      #  @writer_class.new(StringIO.new) do |r|
-      #    writer_mock.got_here
-      #  end
-      #end
+    #it "calls #write_prologue" do
+    #  writer_mock = double("writer")
+    #  writer_mock.should_receive(:got_here)
+    #  writer_class.any_instance.should_receive(:write_prologue)
+    #  writer_class.new(StringIO.new) do |r|
+    #    writer_mock.got_here
+    #  end
+    #end
+    #
+    #it "calls #write_epilogue" do
+    #  writer_mock = double("writer")
+    #  writer_mock.should_receive(:got_here)
+    #  writer_class.any_instance.should_receive(:write_epilogue)
+    #  writer_class.new(StringIO.new) do |r|
+    #    writer_mock.got_here
+    #  end
+    #end
+  end
+
+  describe "#prefixes=" do
+    it "sets prefixes from hash" do
+      writer.prefixes = {:a => "b"}
+      expect(writer.prefixes).to eq({:a => "b"})
     end
-  
-    describe "#prefixes=" do
-      it "sets prefixes from hash" do
-        @writer.prefixes = {:a => "b"}
-        expect(@writer.prefixes).to eq({:a => "b"})
-      end
-    end
-  
-    describe "#prefix" do
-      {
-        nil     => "nil",
-        :a      => "b",
-        "foo"   => "bar",
-      }.each_pair do |pfx, uri|
-        it "sets prefix(#{pfx}) to #{uri}" do
-          expect(@writer.prefix(pfx, uri)).to eq uri
-          expect(@writer.prefix(pfx)).to eq uri
-        end
+  end
+
+  describe "#prefix" do
+    {
+      nil     => "nil",
+      :a      => "b",
+      "foo"   => "bar",
+    }.each_pair do |pfx, uri|
+      it "sets prefix(#{pfx}) to #{uri}" do
+        expect(writer.prefix(pfx, uri)).to eq uri
+        expect(writer.prefix(pfx)).to eq uri
       end
     end
   end


### PR DESCRIPTION
This refactors all the shared example sets to use the newer `shared_example` style definitions. To use these example sets do, e.g.:

```ruby
   it_behaves_like 'an RDF::Enumerable'
```

This also shifts from the pattern of defining `@instance_variables` in a `before` block to using `let` (We might consider using shared example arguments instead).

https://github.com/ruby-rdf/rdf/tree/feature/new-specs updates RDF.rb to use the new example style.  Before cutting a release with these changes, we should have a good plan in place for migrating the various other libraries.

The existing modules remain, and are deprecated.  RDF.rb passes all but four tests when run against this branch.
 
(The four failures are at: 

```
rspec ./spec/ntriples_spec.rb:155 # RDF::NTriples::Reader Surrogate Pairs unescapes [...]
```

and are caused by the ntriples specs there relying on `rdf-spec` to set a `@reader_class` variable, which it no longer does.)