### PR TITLE
Use correct include for Matchers in Reader/Writer

### DIFF
--- a/lib/rdf/spec/reader.rb
+++ b/lib/rdf/spec/reader.rb
@@ -1,7 +1,7 @@
 require 'rdf/spec'
 
 RSpec.shared_examples 'an RDF::Reader' do
-  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
 
   before(:each) do
     raise 'reader must be defined with let(:reader)' unless defined? reader

--- a/lib/rdf/spec/writer.rb
+++ b/lib/rdf/spec/writer.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require 'tmpdir'
 
 RSpec.shared_examples 'an RDF::Writer' do
-  extend RSpec::SharedContext
+  include RDF::Spec::Matchers
 
   before(:each) do
     raise 'writer must be defined with let(:writer)' unless


### PR DESCRIPTION
This fixes an error that caused examples for RDF::Writer & RDF::Reader to be passed over silently.