### PR TITLE
Add a triple pattern matcher

### DIFF
--- a/lib/rdf/spec/matchers.rb
+++ b/lib/rdf/spec/matchers.rb
@@ -34,6 +34,10 @@ module RDF; module Spec
       end
     end
 
+    RSpec::Matchers.define :match_triple_pattern do |*pattern|
+      match { |queryable| not queryable.first(pattern).nil? }
+    end
+
     RSpec::Matchers.define :be_mutable do
       match do |enumerable|
         expect(enumerable).to be_a_kind_of(RDF::Mutable)


### PR DESCRIPTION
This matcher handles checking whether a given pattern is matched in a `Queryable`. e.g.

```ruby
    it { is_expected.to match_triple_pattern [:s, :p, :o] }
```