### PR TITLE
Allow Reader#for to call original

### DIFF
--- a/lib/rdf/spec/mutable.rb
+++ b/lib/rdf/spec/mutable.rb
@@ -76,6 +76,7 @@ RSpec.shared_examples 'an RDF::Mutable' do
       it "should instantiate a reader" do
         reader = double("reader")
         expect(reader).to receive(:new).and_return(RDF::Spec.quads.first)
+        allow(RDF::Reader).to receive(:for).and_call_original
         expect(RDF::Reader).to receive(:for).with(:a_reader).and_return(reader)
         subject.send(:from_a_reader)
       end


### PR DESCRIPTION
This test failed if an implementation of Mutable calls `Reader#for` more
than once. The change allows additional calls with other arguments to
pass through to the original implementation.