### PR TITLE
Fix errant `subject` calls in Repository specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rdf", git: "git://github.com/ruby-rdf/rdf.git", branch: "develop"
+gem "rdf",            git: "git://github.com/ruby-rdf/rdf.git",            branch: "develop"
+gem "rdf-isomorphic", git: "git://github.com/ruby-rdf/rdf-isomorphic.git", branch: "develop"
 
 group :development do
   gem "wirble"

--- a/lib/rdf/spec/dataset.rb
+++ b/lib/rdf/spec/dataset.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples 'an RDF::Dataset' do
   describe '#isolation_level' do
     it 'is an allowable isolation level' do
       expect(described_class::ISOLATION_LEVELS)
-        .to include(subject.isolation_level)
+        .to include(dataset.isolation_level)
     end
   end
 end

--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -31,10 +31,10 @@ RSpec.shared_examples 'an RDF::Repository' do
     
     describe '#delete_insert' do
       it 'updates transactionally' do
-        expect(subject).to receive(:commit_transaction).and_call_original
+        expect(mutable).to receive(:commit_transaction).and_call_original
         statement = RDF::Statement(:s, RDF::URI.new("urn:predicate:1"), :o)
                                     
-        subject.delete_insert([statement], [statement])
+        mutable.delete_insert([statement], [statement])
       end
     end
   end


### PR DESCRIPTION
A few `subject` calls crept in where `mutable` or `dataset` should have
been called instead. These references work fine where no parameters are
required by the `Repository`, but don't test the object given by the
caller and break for, e.g., `SPARQL::Client::Repository`.