### PR TITLE
Expect an error to be raised if trying `Repository#transaction`

### DIFF
--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -42,7 +42,16 @@ RSpec.shared_examples 'an RDF::Repository' do
     end
   end
 
-  describe "#transaction" do
+  describe '#transaction' do
+    it 'is not implemented when #supports(:transactions) is false' do
+      unless subject.supports?(:transactions) 
+        expect { subject.transaction }.to raise_error NotImplementedError
+      end
+    end
+  end
+
+  context "with transaction support" do
+    before {skip "Does not support Transactions" unless subject.supports?(:transactions)}
     it 'gives an immutable transaction' do
       expect { subject.transaction { insert([]) } }.to raise_error TypeError
     end
@@ -73,15 +82,16 @@ RSpec.shared_examples 'an RDF::Repository' do
     end
   end
 
-  context "with snapshot support" do
-
-    describe '#snapshot' do
-      it 'is not implemented when #supports(:snapshots) is false' do
-        unless subject.supports?(:snapshots) 
-          expect { subject.snapshot }.to raise_error NotImplementedError
-        end
+  describe '#snapshot' do
+    it 'is not implemented when #supports(:snapshots) is false' do
+      unless subject.supports?(:snapshots) 
+        expect { subject.snapshot }.to raise_error NotImplementedError
       end
     end
+  end
+
+  context "with snapshot support" do
+    before {skip "Does not support Snapshots" unless subject.supports?(:snapshots)}
 
     it 'returns a queryable #snapshot' do
       if subject.supports? :snapshots

--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -57,6 +57,7 @@ RSpec.shared_examples 'an RDF::Repository' do
     end
 
     it 'commits a successful transaction' do
+      subject.clear!
       statement = RDF::Statement(:s, RDF.type, :o)
       expect(subject).to receive(:commit_transaction).and_call_original
     

--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -42,30 +42,23 @@ RSpec.shared_examples 'an RDF::Repository' do
     end
   end
 
-  describe '#transaction' do
-    it 'is not implemented when #supports(:transactions) is false' do
-      unless subject.supports?(:transactions) 
-        expect { subject.transaction }.to raise_error NotImplementedError
-      end
-    end
-  end
-
-  context "with transaction support" do
-    before {skip "Does not support Transactions" unless subject.supports?(:transactions)}
+  describe "#transaction'" do
     it 'gives an immutable transaction' do
       expect { subject.transaction { insert([]) } }.to raise_error TypeError
     end
 
     it 'commits a successful transaction' do
-      subject.clear!
-      statement = RDF::Statement(:s, RDF.type, :o)
-      expect(subject).to receive(:commit_transaction).and_call_original
+      if subject.mutable?
+        subject.clear!
+        statement = RDF::Statement(:s, RDF.type, :o)
+        expect(subject).to receive(:commit_transaction).and_call_original
     
-      expect do
-        subject.transaction(mutable: true) do
-          insert(statement)
-        end
-      end.to change { subject.statements }.to contain_exactly(statement)
+        expect do
+          subject.transaction(mutable: true) do
+            insert(statement)
+          end
+        end.to change { subject.statements }.to contain_exactly(statement)
+      end
     end
 
     it 'rolls back a failed transaction' do


### PR DESCRIPTION
 when the repository does not support transactions.