### PR TITLE
Better testing for Literal Equality

### DIFF
--- a/lib/rdf/spec/mutable.rb
+++ b/lib/rdf/spec/mutable.rb
@@ -204,12 +204,24 @@ RSpec.shared_examples 'an RDF::Mutable' do
 
       it 'does not delete literal with different datatype' do
         if subject.mutable? && @supports_literal_equality
-          float = RDF::Literal::Float.new(1.0)
-          double = RDF::Literal::Double.new(1.0)
+          dec = RDF::Literal::Decimal.new(1)
+          int = RDF::Literal::Integer.new(1)
 
-          subject.insert([RDF::URI('s'), RDF::URI('p'), float])
+          subject.insert([RDF::URI('s'), RDF::URI('p'), dec])
           
-          expect { subject.delete([RDF::URI('s'), RDF::URI('p'), double]) }
+          expect { subject.delete([RDF::URI('s'), RDF::URI('p'), int]) }
+            .not_to change { subject.count }
+        end
+      end
+
+      it 'does not delete literal with different lexical value' do
+        if subject.mutable? && @supports_literal_equality
+          one      = RDF::Literal::Integer.new("1")
+          zero_one = RDF::Literal::Integer.new("01")
+
+          subject.insert([RDF::URI('s'), RDF::URI('p'), one])
+          
+          expect { subject.delete([RDF::URI('s'), RDF::URI('p'), zero_one]) }
             .not_to change { subject.count }
         end
       end

--- a/lib/rdf/spec/writable.rb
+++ b/lib/rdf/spec/writable.rb
@@ -103,10 +103,22 @@ RSpec.shared_examples 'an RDF::Writable' do
 
     it "should insert statement with literal with unique datatype" do
       if subject.writable? && supports_literal_equality
-        statement.object = RDF::Literal::Float.new(1.0)
+        statement.object = RDF::Literal::Decimal.new(1)
         subject.insert(statement)
 
-        statement.object = RDF::Literal::Double.new(1.0)
+        statement.object = RDF::Literal::Integer.new(1)
+        subject.insert(statement)
+
+        expect(subject.count).to eq 2
+      end
+    end
+
+    it 'inserts literal with unique lexical value' do
+      if subject.writable? && supports_literal_equality
+        statement.object = RDF::Literal::Integer.new("1")
+        subject.insert(statement)
+
+        statement.object = RDF::Literal::Integer.new("01")
         subject.insert(statement)
 
         expect(subject.count).to eq 2


### PR DESCRIPTION
Adds a test for RDF term-equality distinctions in lexical space ('1' vs. '01').

Changes the test for datatype-based inequality to more explicitly equal xsd values: _decimal_ "1" and _integer_ "1". Equivalent numbers in _float_ and _double_ value spaces are not (but may be treated as) equal per https://www.w3.org/TR/xmlschema11-2/#equality. The new test is, therefore, slightly less likely to pass simply because the implementation distinguishes between numbers in xsd value spaces.