### PR TITLE
Feature/transactable bnodes

### DIFF
--- a/lib/rdf/spec/repository.rb
+++ b/lib/rdf/spec/repository.rb
@@ -48,35 +48,6 @@ RSpec.shared_examples 'an RDF::Repository' do
     end
   end
 
-  describe "#transaction" do
-    it 'gives an immutable transaction' do
-      expect { subject.transaction { insert([]) } }.to raise_error TypeError
-    end
-
-    it 'commits a successful transaction' do
-      statement = RDF::Statement(:s, RDF.type, :o)
-      expect(subject).to receive(:commit_transaction).and_call_original
-      
-      expect do
-        subject.transaction(mutable: true) { insert(statement) }
-      end.to change { subject.statements }.to include(statement)
-    end
-
-    it 'rolls back a failed transaction' do
-      original_contents = subject.statements
-      expect(subject).to receive(:rollback_transaction).and_call_original
-
-      expect do
-        subject.transaction(mutable: true) do
-          delete(*@statements)
-          raise 'my error'
-        end
-      end.to raise_error RuntimeError
-
-      expect(subject.statements).to contain_exactly(*original_contents)
-    end
-  end
-
   context "with snapshot support" do
 
     describe '#snapshot' do

--- a/lib/rdf/spec/transactable.rb
+++ b/lib/rdf/spec/transactable.rb
@@ -18,7 +18,9 @@ RSpec.shared_examples 'an RDF::Transactable' do
     end
 
     it 'commits a successful transaction' do
-      statement = RDF::Statement(:s, RDF.type, :o)
+      statement = RDF::Statement(RDF::URI('http://example.com/s'), 
+                                 RDF.type, 
+                                 RDF::URI('http://example.com/o'))
       expect(subject).to receive(:commit_transaction).and_call_original
       
       expect do


### PR DESCRIPTION
0acb718 is the main change. It avoids testing bnode identifiers in `#transactable`.

a811c4b simply removes duplicate tests from `RDF::Repository`. These tests are run as part of the included `RDF::Transactable` suite.