### PR TITLE
Add Ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ script: "bundle exec rspec spec"
 env:
   - CI=true
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0  
   - jruby
   - rbx
 cache: bundler

--- a/rdf-spec.gemspec
+++ b/rdf-spec.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency     'rdf-isomorphic',  '~> 2.0'
   gem.add_runtime_dependency     'rspec',           '~> 3.0'
   gem.add_runtime_dependency     'rspec-its',       '~> 1.0'
-  gem.add_runtime_dependency     'webmock',         '~> 1.17'
+  gem.add_runtime_dependency     'webmock',         '~> 2.3'
   gem.add_development_dependency 'yard' ,           '~> 0.8'
   gem.post_install_message       = nil
 end


### PR DESCRIPTION
Updates the build matrix match RDF.rb, and adds 2.4.0.

Updates the dependency on `webmock` to 2.x to avoid errors due to lack of Ruby 2.4 support in `webmock` 1.x.